### PR TITLE
Fix #1: Make UML canvas prefer code map IR

### DIFF
--- a/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
+++ b/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
@@ -1,5 +1,6 @@
 package com.blueprint.ui
 
+import com.blueprint.ir.IRStore
 import com.blueprint.model.AcceptanceCriterion
 import com.blueprint.model.AcceptanceCriterionType
 import com.blueprint.model.BlueprintNode
@@ -313,6 +314,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
     private val advancedMode = JBCheckBox("Advanced")
     private val filterCombo = JComboBox(NodeFilter.values())
     private var umlHasPendingEdits = false
+    private var suppressUmlDocumentEvents = false
     private val activityLog = JBTextArea(6, 40).apply {
         isEditable = false
         lineWrap = true
@@ -366,9 +368,9 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
 
     init {
         umlEditor.document.addDocumentListener(object : DocumentListener {
-            override fun insertUpdate(e: DocumentEvent) = refreshCanvasFromUml()
-            override fun removeUpdate(e: DocumentEvent) = refreshCanvasFromUml()
-            override fun changedUpdate(e: DocumentEvent) = refreshCanvasFromUml()
+            override fun insertUpdate(e: DocumentEvent) = umlDocumentChanged()
+            override fun removeUpdate(e: DocumentEvent) = umlDocumentChanged()
+            override fun changedUpdate(e: DocumentEvent) = umlDocumentChanged()
         })
         buildUi()
         seedInitialChat()
@@ -1086,9 +1088,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
                     status("UML unchanged")
                     return@invokeLater
                 }
-                umlEditor.text = nextUml
-                umlEditor.caretPosition = 0
-                umlHasPendingEdits = true
+                setUmlEditorText(nextUml, pendingEdits = true)
                 umlStatusLabel.text = "UML: refined by chat. Create Code Nodes when ready, or keep editing."
                 appendChat("Blueprint", "Updated the UML. Review it in the main canvas, then keep refining or click Create Code Nodes.")
                 updateGuide()
@@ -1199,9 +1199,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         if (!confirmDiscardPendingUmlEdits()) return
         status("Generating UML from Python project...")
         val generated = project.service<PythonUmlGenerator>().generate()
-        umlEditor.text = generated.text
-        umlEditor.caretPosition = 0
-        umlHasPendingEdits = false
+        setUmlEditorText(generated.text, pendingEdits = false)
         umlStatusLabel.text = "UML: ${generated.classCount} class(es), ${generated.relationshipCount} relationship(s), ${generated.filesScanned} file(s) scanned."
         graphArea.text = buildString {
             appendLine("Abstracted Python codebase to editable UML.")
@@ -1261,9 +1259,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
             status("No UML text supplied")
             return
         }
-        umlEditor.text = text
-        umlEditor.caretPosition = 0
-        umlHasPendingEdits = true
+        setUmlEditorText(text, pendingEdits = true)
         umlStatusLabel.text = "UML: pasted/loaded. Edit or ask chat to refine it."
         appendChat("Blueprint", "Loaded pasted UML into the main editor. Keep refining it, then click Create Code Nodes.")
         status("Loaded UML into editor")
@@ -2150,7 +2146,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         if (node == null) {
             selectedCanvasId = id
             updateMiniGraph(project.service<DependencyGraphService>().analyze())
-            status("Selected UML entity: $id")
+            status("Selected canvas entity: $id")
             return
         }
         selectedCanvasId = id
@@ -2162,6 +2158,26 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         loadSelectedIntoForm()
         status("Selected from graph: ${node.title.ifBlank { node.id.take(8) }}")
         logActivity("Graph selected ${node.title.ifBlank { node.id.take(8) }} (${node.id.take(8)}).")
+    }
+
+    private fun setUmlEditorText(text: String, pendingEdits: Boolean) {
+        suppressUmlDocumentEvents = true
+        try {
+            umlEditor.text = text
+            umlEditor.caretPosition = 0
+            umlHasPendingEdits = pendingEdits
+        } finally {
+            suppressUmlDocumentEvents = false
+        }
+        updateMiniGraph(project.service<DependencyGraphService>().analyze())
+        updateGuide()
+    }
+
+    private fun umlDocumentChanged() {
+        if (!suppressUmlDocumentEvents) {
+            umlHasPendingEdits = true
+        }
+        refreshCanvasFromUml()
     }
 
     private fun refreshCanvasFromUml() {
@@ -2277,9 +2293,14 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
 
     private fun updateMiniGraph(report: DependencyGraphService.GraphReport) {
         val selectedId = nodeList.selectedValue?.id
-        val umlViews = umlCanvasViews(selectedId)
-        if (umlViews.isNotEmpty()) {
-            miniGraph.setGraph(umlViews)
+        val proposalViews = if (umlHasPendingEdits) umlCanvasViews(selectedId) else emptyList()
+        if (proposalViews.isNotEmpty()) {
+            miniGraph.setGraph(proposalViews)
+            return
+        }
+        val codeViews = codeMapViews(selectedId, report)
+        if (codeViews.isNotEmpty()) {
+            miniGraph.setGraph(codeViews)
             return
         }
         val views = registry.all().map { node ->
@@ -2294,9 +2315,37 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
                 ready = readiness?.ready == true,
                 blocked = hasDependencyBlock(readiness) || badgeFor(node) == "BLOCKED" || badgeFor(node) == "PARTIAL",
                 detail = graphNodeDetail(node, readiness),
+                origin = MiniGraphPanel.NodeOrigin.WORKFLOW,
+                kind = node.type.name.lowercase(),
+                source = node.fileScope.paths.firstOrNull().orEmpty(),
+                preview = readiness?.let { if (it.ready) "ready to run" else it.reasons.firstOrNull().orEmpty() }.orEmpty(),
             )
         }
         miniGraph.setGraph(views)
+    }
+
+    private fun codeMapViews(
+        selectedNodeId: String?,
+        report: DependencyGraphService.GraphReport,
+    ): List<MiniGraphPanel.NodeView> {
+        val ir = project.service<IRStore>().load() ?: return emptyList()
+        val workflowByComponent = registry.all()
+            .mapNotNull { node ->
+                val componentId = node.metadata["componentId"] ?: return@mapNotNull null
+                val readiness = report.readiness[node.id]
+                componentId to CodeMapProjection.WorkflowBadge(
+                    status = badgeFor(node),
+                    ready = readiness?.ready == true,
+                    blocked = hasDependencyBlock(readiness) || badgeFor(node) == "BLOCKED" || badgeFor(node) == "PARTIAL",
+                    selected = node.id == selectedNodeId,
+                )
+            }
+            .toMap()
+        return CodeMapProjection.fromIr(
+            ir = ir,
+            selectedId = selectedCanvasId ?: selectedNodeId,
+            workflowByComponentId = workflowByComponent,
+        )
     }
 
     private fun umlCanvasViews(selectedNodeId: String?): List<MiniGraphPanel.NodeView> {
@@ -2318,12 +2367,15 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
                 ready = true,
                 blocked = false,
                 detail = buildString {
-                    append("Editable UML entity")
+                    append("Proposed UML entity")
                     if (entity.fields.isNotEmpty()) {
                         append("\n")
                         append(entity.fields.take(8).joinToString("\n") { "- $it" })
                     }
                 },
+                origin = MiniGraphPanel.NodeOrigin.PROPOSED_UML,
+                kind = "UML entity",
+                preview = entity.fields.take(3).joinToString(", ").ifBlank { "no fields yet" },
             )
         }
     }

--- a/src/main/kotlin/com/blueprint/ui/CodeMapProjection.kt
+++ b/src/main/kotlin/com/blueprint/ui/CodeMapProjection.kt
@@ -1,0 +1,104 @@
+package com.blueprint.ui
+
+import com.blueprint.ir.ArchitectureIR
+import com.blueprint.ir.Component
+import com.blueprint.ir.ComponentKind
+import com.blueprint.ir.EdgeTargetKind
+
+/**
+ * Pure projection from the recovered architecture IR into the canvas model.
+ * The canvas should read as current code first; generated workflow state is
+ * optional metadata layered onto those code entities.
+ */
+object CodeMapProjection {
+    data class WorkflowBadge(
+        val status: String,
+        val ready: Boolean,
+        val blocked: Boolean,
+        val selected: Boolean,
+    )
+
+    fun fromIr(
+        ir: ArchitectureIR,
+        selectedId: String?,
+        workflowByComponentId: Map<String, WorkflowBadge> = emptyMap(),
+    ): List<MiniGraphPanel.NodeView> {
+        if (ir.components.isEmpty()) return emptyList()
+
+        val componentsById = ir.components.associateBy { it.id }
+        val dependenciesById = ir.edges
+            .filter { it.toKind == EdgeTargetKind.COMPONENT }
+            .filter { it.from in componentsById && it.to in componentsById }
+            .groupBy({ it.to }, { it.from })
+            .mapValues { (_, deps) -> deps.distinct() }
+
+        val waveMemo = mutableMapOf<String, Int>()
+        fun waveOf(id: String, visiting: Set<String> = emptySet()): Int {
+            waveMemo[id]?.let { return it }
+            if (id in visiting) return 1
+            val deps = dependenciesById[id].orEmpty().filter { it in componentsById }
+            val wave = if (deps.isEmpty()) {
+                1
+            } else {
+                deps.maxOf { waveOf(it, visiting + id) + 1 }.coerceAtMost(8)
+            }
+            waveMemo[id] = wave
+            return wave
+        }
+
+        return ir.components
+            .sortedWith(compareBy<Component>({ waveOf(it.id) }, { it.ownership.files.firstOrNull() ?: "" }, { it.name }))
+            .map { component ->
+                val workflow = workflowByComponentId[component.id]
+                MiniGraphPanel.NodeView(
+                    id = component.id,
+                    title = component.name,
+                    status = workflow?.status ?: "CODE",
+                    wave = waveOf(component.id),
+                    dependencies = dependenciesById[component.id].orEmpty(),
+                    selected = workflow?.selected == true || selectedId == component.id || selectedId == component.name,
+                    ready = workflow?.ready ?: true,
+                    blocked = workflow?.blocked ?: false,
+                    detail = detailFor(component),
+                    origin = MiniGraphPanel.NodeOrigin.CODE,
+                    kind = component.kind.codeMapLabel(),
+                    source = component.primarySource(),
+                    preview = previewFor(component),
+                )
+            }
+    }
+
+    private fun detailFor(component: Component): String = buildString {
+        append("Current code entity")
+        append("\nType: ${component.kind.codeMapLabel()}")
+        component.primarySource().takeIf { it.isNotBlank() }?.let { append("\nSource: $it") }
+        if (component.fields.isNotEmpty()) {
+            append("\nFields:")
+            component.fields.take(8).forEach { append("\n- ${it.name}: ${it.type}") }
+            if (component.fields.size > 8) append("\n- +${component.fields.size - 8} more field(s)")
+        }
+        if (component.operations.isNotEmpty()) {
+            append("\nOperations:")
+            component.operations.take(6).forEach { append("\n- ${it.name}()") }
+            if (component.operations.size > 6) append("\n- +${component.operations.size - 6} more operation(s)")
+        }
+    }
+
+    private fun previewFor(component: Component): String {
+        if (component.fields.isNotEmpty()) {
+            return "fields: " + component.fields.take(3).joinToString(", ") { it.name } +
+                (if (component.fields.size > 3) ", +" + (component.fields.size - 3) else "")
+        }
+        if (component.operations.isNotEmpty()) {
+            return "ops: " + component.operations.take(3).joinToString(", ") { "${it.name}()" } +
+                (if (component.operations.size > 3) ", +" + (component.operations.size - 3) else "")
+        }
+        return component.description.substringBefore('.').take(48)
+    }
+
+    private fun Component.primarySource(): String =
+        ownership.files.firstOrNull() ?: sourceRef?.path.orEmpty()
+
+    private fun ComponentKind.codeMapLabel(): String =
+        name.lowercase().replace('_', ' ')
+}

--- a/src/main/kotlin/com/blueprint/ui/MiniGraphPanel.kt
+++ b/src/main/kotlin/com/blueprint/ui/MiniGraphPanel.kt
@@ -40,6 +40,12 @@ class MiniGraphPanel : JPanel() {
         val PurpleSurface = Color(0x2B2842)
     }
 
+    enum class NodeOrigin {
+        CODE,
+        PROPOSED_UML,
+        WORKFLOW,
+    }
+
     data class NodeView(
         val id: String,
         val title: String,
@@ -50,6 +56,10 @@ class MiniGraphPanel : JPanel() {
         val ready: Boolean,
         val blocked: Boolean,
         val detail: String,
+        val origin: NodeOrigin = NodeOrigin.WORKFLOW,
+        val kind: String = "",
+        val source: String = "",
+        val preview: String = "",
     )
 
     private var nodes: List<NodeView> = emptyList()
@@ -89,7 +99,10 @@ class MiniGraphPanel : JPanel() {
         nodeAt(event.point)?.let { node ->
             "<html><b>${escape(node.title)}</b><br/>" +
                 "ID: ${node.id.take(8)}<br/>" +
+                "Origin: ${node.origin.label()}<br/>" +
                 "Status: ${node.status}<br/>" +
+                node.kind.takeIf { it.isNotBlank() }?.let { "Kind: ${escape(it)}<br/>" }.orEmpty() +
+                node.source.takeIf { it.isNotBlank() }?.let { "Source: ${escape(it)}<br/>" }.orEmpty() +
                 "Wave: ${node.wave}<br/>" +
                 escape(node.detail).replace("\n", "<br/>") +
                 "</html>"
@@ -117,8 +130,8 @@ class MiniGraphPanel : JPanel() {
         }
 
         val waves = nodes.groupBy { it.wave }.toSortedMap()
-        val cardW = 190f
-        val cardH = 60f
+        val cardW = 230f
+        val cardH = 76f
         val gapX = 70f
         val gapY = 24f
         val startX = 24f
@@ -154,19 +167,29 @@ class MiniGraphPanel : JPanel() {
 
         nodes.forEach { node ->
             val card = localCards[node.id] ?: return@forEach
-            val fill = colorFor(node.status, node.ready, node.blocked)
+            val fill = colorFor(node)
             g.color = fill
             g.fill(card)
-            g.color = if (node.selected) Theme.Accent else borderFor(node.status, node.ready, node.blocked)
+            g.color = if (node.selected) Theme.Accent else borderFor(node)
             g.stroke = BasicStroke(if (node.selected) 3.0f else 1.3f)
             g.draw(card)
 
             g.color = Theme.TextStrong
             g.font = font.deriveFont(Font.BOLD, 12f)
-            g.drawString(node.title.take(25), (card.x + 12).toInt(), (card.y + 23).toInt())
+            g.drawString(node.title.ellipsize(28), (card.x + 12).toInt(), (card.y + 22).toInt())
+
             g.font = font.deriveFont(Font.PLAIN, 11f)
             g.color = Theme.Muted
-            g.drawString("${node.status}  ${node.id.take(8)}", (card.x + 12).toInt(), (card.y + 45).toInt())
+            val metadata = node.metadataLine()
+            g.drawString(metadata.ellipsize(32), (card.x + 12).toInt(), (card.y + 42).toInt())
+
+            val preview = node.preview.ifBlank { node.detail.lineSequence().drop(1).firstOrNull().orEmpty() }
+            if (preview.isNotBlank()) {
+                g.color = Theme.Muted
+                g.drawString(preview.ellipsize(34), (card.x + 12).toInt(), (card.y + 60).toInt())
+            }
+
+            paintStatusBadge(g, node, card)
 
             g.color = if (node.selected) Theme.Accent else Theme.Muted
             g.drawOval((card.x + card.width - 28).toInt(), (card.y + 10).toInt(), 16, 16)
@@ -197,31 +220,89 @@ class MiniGraphPanel : JPanel() {
         return nodes.firstOrNull { it.id == id }
     }
 
-    private fun colorFor(status: String, ready: Boolean, blocked: Boolean): Color {
-        if (blocked || status == "BLOCKED") return Theme.DangerSurface
-        return when (status) {
-            "UML" -> Theme.Surface
-            "APPLIED" -> Theme.SuccessSurface
-            "REVIEWED" -> Theme.PurpleSurface
-            "EXECUTED" -> Theme.AccentSurface
-            "PLANNED" -> Theme.WarningSurface
-            "PARTIAL" -> Theme.WarningSurface
-            else -> if (ready) Theme.SuccessSurface else Theme.SurfaceSoft
+    private fun paintStatusBadge(g: Graphics2D, node: NodeView, card: RoundRectangle2D.Float) {
+        val label = when {
+            node.origin == NodeOrigin.CODE && node.status == "CODE" -> "code"
+            node.origin == NodeOrigin.PROPOSED_UML -> "proposal"
+            else -> node.status.lowercase()
+        }.ellipsize(12)
+        val width = (label.length * 7 + 14).coerceAtLeast(42)
+        val x = (card.x + card.width - width - 10).toInt()
+        val y = (card.y + card.height - 22).toInt()
+        val pill = RoundRectangle2D.Float(x.toFloat(), y.toFloat(), width.toFloat(), 16f, 8f, 8f)
+        g.color = badgeFill(node)
+        g.fill(pill)
+        g.color = badgeText(node)
+        g.font = font.deriveFont(Font.PLAIN, 10f)
+        g.drawString(label, x + 7, y + 12)
+    }
+
+    private fun colorFor(node: NodeView): Color {
+        if (node.blocked || node.status == "BLOCKED") return Theme.DangerSurface
+        return when (node.origin) {
+            NodeOrigin.CODE -> Theme.Surface
+            NodeOrigin.PROPOSED_UML -> Theme.PurpleSurface
+            NodeOrigin.WORKFLOW -> when (node.status) {
+                "APPLIED" -> Theme.SuccessSurface
+                "REVIEWED" -> Theme.PurpleSurface
+                "EXECUTED" -> Theme.AccentSurface
+                "PLANNED" -> Theme.WarningSurface
+                "PARTIAL" -> Theme.WarningSurface
+                else -> if (node.ready) Theme.SuccessSurface else Theme.SurfaceSoft
+            }
         }
     }
 
-    private fun borderFor(status: String, ready: Boolean, blocked: Boolean): Color {
-        if (blocked || status == "BLOCKED") return Theme.Danger
-        return when (status) {
-            "UML" -> Theme.Border
-            "APPLIED" -> Theme.Success
-            "PARTIAL" -> Theme.Warning
-            "REVIEWED" -> Theme.Accent
-            "EXECUTED" -> Theme.Accent
-            "PLANNED" -> Theme.Warning
-            else -> if (ready) Theme.Success else Theme.Border
+    private fun borderFor(node: NodeView): Color {
+        if (node.blocked || node.status == "BLOCKED") return Theme.Danger
+        return when (node.origin) {
+            NodeOrigin.CODE -> Theme.Accent
+            NodeOrigin.PROPOSED_UML -> Theme.Warning
+            NodeOrigin.WORKFLOW -> when (node.status) {
+                "APPLIED" -> Theme.Success
+                "PARTIAL" -> Theme.Warning
+                "REVIEWED" -> Theme.Accent
+                "EXECUTED" -> Theme.Accent
+                "PLANNED" -> Theme.Warning
+                else -> if (node.ready) Theme.Success else Theme.Border
+            }
         }
     }
+
+    private fun badgeFill(node: NodeView): Color =
+        when {
+            node.blocked || node.status == "BLOCKED" -> Theme.Danger
+            node.origin == NodeOrigin.CODE -> Theme.AccentSurface
+            node.origin == NodeOrigin.PROPOSED_UML -> Theme.WarningSurface
+            node.status == "APPLIED" -> Theme.SuccessSurface
+            node.status == "PLANNED" || node.status == "PARTIAL" -> Theme.WarningSurface
+            else -> Theme.SurfaceSoft
+        }
+
+    private fun badgeText(node: NodeView): Color =
+        when {
+            node.blocked || node.status == "BLOCKED" -> Theme.TextStrong
+            node.origin == NodeOrigin.CODE -> Theme.Accent
+            node.origin == NodeOrigin.PROPOSED_UML -> Theme.Warning
+            else -> Theme.TextStrong
+        }
+
+    private fun NodeView.metadataLine(): String =
+        when (origin) {
+            NodeOrigin.CODE -> listOf(kind.ifBlank { "code" }, source).filter { it.isNotBlank() }.joinToString("  ")
+            NodeOrigin.PROPOSED_UML -> listOf(kind.ifBlank { "UML proposal" }, "editable").joinToString("  ")
+            NodeOrigin.WORKFLOW -> listOf(kind.ifBlank { "workflow" }, id.take(8)).joinToString("  ")
+        }
+
+    private fun NodeOrigin.label(): String =
+        when (this) {
+            NodeOrigin.CODE -> "Current code"
+            NodeOrigin.PROPOSED_UML -> "Proposed UML"
+            NodeOrigin.WORKFLOW -> "Implementation workflow"
+        }
+
+    private fun String.ellipsize(max: Int): String =
+        if (length <= max) this else take((max - 3).coerceAtLeast(0)) + "..."
 
     private fun escape(text: String): String =
         buildString {

--- a/src/test/kotlin/com/blueprint/ui/CodeMapProjectionTest.kt
+++ b/src/test/kotlin/com/blueprint/ui/CodeMapProjectionTest.kt
@@ -1,0 +1,99 @@
+package com.blueprint.ui
+
+import com.blueprint.ir.ArchitectureIR
+import com.blueprint.ir.Component
+import com.blueprint.ir.ComponentKind
+import com.blueprint.ir.Edge
+import com.blueprint.ir.EdgeKind
+import com.blueprint.ir.EdgeTargetKind
+import com.blueprint.ir.Field
+import com.blueprint.ir.Operation
+import com.blueprint.ir.Ownership
+import com.blueprint.ir.ProjectMeta
+import com.blueprint.ir.TypeRef
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CodeMapProjectionTest {
+    @Test
+    fun `projects architecture ir into current-code canvas views`() {
+        val ir = ArchitectureIR(
+            project = ProjectMeta(name = "invite_project"),
+            components = listOf(
+                Component(
+                    id = "models.project",
+                    name = "Project",
+                    kind = ComponentKind.MODEL,
+                    ownership = Ownership(files = listOf("app/models.py")),
+                    fields = listOf(Field("id", TypeRef("str")), Field("owner", TypeRef("User"))),
+                ),
+                Component(
+                    id = "models.invite",
+                    name = "Invite",
+                    kind = ComponentKind.MODEL,
+                    ownership = Ownership(files = listOf("app/models.py")),
+                    fields = listOf(Field("id", TypeRef("str")), Field("project", TypeRef("Project"))),
+                ),
+                Component(
+                    id = "services.invite",
+                    name = "InviteService",
+                    kind = ComponentKind.SERVICE,
+                    ownership = Ownership(files = listOf("app/service.py")),
+                    operations = listOf(Operation("create_invite")),
+                ),
+            ),
+            edges = listOf(
+                Edge("models.project", "models.invite", EdgeTargetKind.COMPONENT, EdgeKind.REFERENCES, "project"),
+                Edge("models.invite", "services.invite", EdgeTargetKind.COMPONENT, EdgeKind.REFERENCES, "invite"),
+            ),
+        )
+
+        val views = CodeMapProjection.fromIr(ir, selectedId = "models.invite")
+
+        assertEquals(3, views.size)
+        assertTrue(views.all { it.origin == MiniGraphPanel.NodeOrigin.CODE })
+
+        val invite = views.single { it.id == "models.invite" }
+        assertEquals("Invite", invite.title)
+        assertEquals("CODE", invite.status)
+        assertEquals("model", invite.kind)
+        assertEquals("app/models.py", invite.source)
+        assertEquals(listOf("models.project"), invite.dependencies)
+        assertTrue(invite.selected)
+        assertTrue(invite.detail.contains("Current code entity"))
+        assertTrue(invite.preview.contains("project"))
+    }
+
+    @Test
+    fun `workflow badge stays secondary on code map views`() {
+        val ir = ArchitectureIR(
+            components = listOf(
+                Component(
+                    id = "models.invite",
+                    name = "Invite",
+                    kind = ComponentKind.MODEL,
+                    ownership = Ownership(files = listOf("app/models.py")),
+                ),
+            ),
+        )
+
+        val views = CodeMapProjection.fromIr(
+            ir = ir,
+            selectedId = null,
+            workflowByComponentId = mapOf(
+                "models.invite" to CodeMapProjection.WorkflowBadge(
+                    status = "APPLIED",
+                    ready = false,
+                    blocked = false,
+                    selected = true,
+                )
+            ),
+        )
+
+        val invite = views.single()
+        assertEquals(MiniGraphPanel.NodeOrigin.CODE, invite.origin)
+        assertEquals("APPLIED", invite.status)
+        assertTrue(invite.selected)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a pure ArchitectureIR -> canvas projection so the UML canvas can render current code entities first.
- Distinguish current code, proposed UML, and implementation workflow node origins visually in the mini graph.
- Keep workflow status as secondary card metadata and repaint from saved IR after Refresh UML From Code.
- Add tests for the code-map projection and workflow badge behavior.

## Tests
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew test --no-daemon

Fixes #1