### PR TITLE
Fix #3/#4: Use Python AST for codebase UML extraction

### DIFF
--- a/src/main/kotlin/com/blueprint/ir/MermaidProjector.kt
+++ b/src/main/kotlin/com/blueprint/ir/MermaidProjector.kt
@@ -88,7 +88,7 @@ object MermaidProjection {
                     EdgeKind.READS -> "reads"
                     EdgeKind.WRITES -> "writes"
                 }
-                "$from --> $to : $label"
+                "$from --> $to : ${edge.label.ifBlank { label }}"
             }
             .distinct()
             .sorted()

--- a/src/main/kotlin/com/blueprint/ir/PythonAstParser.kt
+++ b/src/main/kotlin/com/blueprint/ir/PythonAstParser.kt
@@ -1,0 +1,384 @@
+package com.blueprint.ir
+
+import com.google.gson.Gson
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/**
+ * Uses Python's built-in ast module as Blueprint's structural Python parser.
+ *
+ * This avoids depending on a particular JetBrains Python plugin while still
+ * parsing real Python syntax: multiline signatures, decorators, imports,
+ * annotations, module functions, and method bodies.
+ */
+object PythonAstParser {
+    private val gson = Gson()
+
+    data class ParseResult(
+        val symbols: List<Symbol>,
+        val warnings: List<String>,
+        val usedAst: Boolean,
+    )
+
+    data class Symbol(
+        val name: String,
+        val symbolKind: String,
+        val bases: List<String>,
+        val relPath: String,
+        val line: Int,
+        val decorators: List<String>,
+        val fields: List<FieldDecl>,
+        val methods: List<MethodDecl>,
+        val imports: List<String>,
+        val calls: List<String>,
+        val references: List<String>,
+        val routePaths: List<String>,
+    )
+
+    data class FieldDecl(val name: String, val type: String)
+
+    data class MethodDecl(
+        val name: String,
+        val async: Boolean,
+        val params: List<ParamDecl>,
+        val returns: String,
+        val decorators: List<String>,
+        val line: Int,
+    )
+
+    data class ParamDecl(val name: String, val type: String, val default: String?)
+
+    fun parse(base: Path, files: List<Path>, timeoutSeconds: Long = 15): ParseResult {
+        if (files.isEmpty()) return ParseResult(emptyList(), emptyList(), usedAst = true)
+        val python = findPythonExecutable()
+            ?: return ParseResult(emptyList(), listOf("python3 was not found; falling back to legacy Python parser."), usedAst = false)
+
+        val request = AstRequest(
+            base = base.toAbsolutePath().normalize().toString(),
+            files = files.map { it.toAbsolutePath().normalize().toString() },
+        )
+        return try {
+            val process = ProcessBuilder(python, "-c", AST_SCRIPT)
+                .redirectErrorStream(false)
+                .start()
+            OutputStreamWriter(process.outputStream, StandardCharsets.UTF_8).use { writer ->
+                gson.toJson(request, writer)
+            }
+            val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+            if (!finished) {
+                process.destroyForcibly()
+                return ParseResult(emptyList(), listOf("Python AST parser timed out; falling back to legacy parser."), usedAst = false)
+            }
+            val stdout = process.inputStream.readBytes().toString(StandardCharsets.UTF_8)
+            val stderr = process.errorStream.readBytes().toString(StandardCharsets.UTF_8).trim()
+            if (process.exitValue() != 0) {
+                val detail = stderr.ifBlank { "exit ${process.exitValue()}" }
+                return ParseResult(emptyList(), listOf("Python AST parser failed: $detail"), usedAst = false)
+            }
+            val output = gson.fromJson(stdout, AstOutput::class.java)
+            ParseResult(
+                symbols = output.symbols.map { it.toSymbol() },
+                warnings = output.warnings + stderr.takeIf { it.isNotBlank() }.orEmpty().let { if (it.isBlank()) emptyList() else listOf(it) },
+                usedAst = true,
+            )
+        } catch (t: Throwable) {
+            ParseResult(emptyList(), listOf("Python AST parser failed: ${t.message ?: t.javaClass.simpleName}"), usedAst = false)
+        }
+    }
+
+    private fun findPythonExecutable(): String? {
+        val candidates = listOf("python3", "python")
+        return candidates.firstOrNull { exe ->
+            try {
+                val process = ProcessBuilder(exe, "--version").redirectErrorStream(true).start()
+                process.waitFor(3, TimeUnit.SECONDS) && process.exitValue() == 0
+            } catch (_: Throwable) {
+                false
+            }
+        }
+    }
+
+    private data class AstRequest(val base: String, val files: List<String>)
+
+    private data class AstOutput(
+        val symbols: List<AstSymbol> = emptyList(),
+        val warnings: List<String> = emptyList(),
+    )
+
+    private data class AstSymbol(
+        val name: String = "",
+        val symbolKind: String = "CLASS",
+        val bases: List<String> = emptyList(),
+        val relPath: String = "",
+        val line: Int = 1,
+        val decorators: List<String> = emptyList(),
+        val fields: List<AstField> = emptyList(),
+        val methods: List<AstMethod> = emptyList(),
+        val imports: List<String> = emptyList(),
+        val calls: List<String> = emptyList(),
+        val references: List<String> = emptyList(),
+        val routePaths: List<String> = emptyList(),
+    ) {
+        fun toSymbol(): Symbol = Symbol(
+            name = name,
+            symbolKind = symbolKind,
+            bases = bases,
+            relPath = relPath,
+            line = line,
+            decorators = decorators,
+            fields = fields.map { FieldDecl(it.name, it.type) },
+            methods = methods.map { it.toMethod() },
+            imports = imports,
+            calls = calls,
+            references = references,
+            routePaths = routePaths,
+        )
+    }
+
+    private data class AstField(val name: String = "", val type: String = "Any")
+
+    private data class AstMethod(
+        val name: String = "",
+        val async: Boolean = false,
+        val params: List<AstParam> = emptyList(),
+        val returns: String = "None",
+        val decorators: List<String> = emptyList(),
+        val line: Int = 1,
+    ) {
+        fun toMethod(): MethodDecl = MethodDecl(
+            name = name,
+            async = async,
+            params = params.map { ParamDecl(it.name, it.type, it.default) },
+            returns = returns,
+            decorators = decorators,
+            line = line,
+        )
+    }
+
+    private data class AstParam(
+        val name: String = "",
+        val type: String = "Any",
+        val default: String? = null,
+    )
+
+    private const val AST_SCRIPT = """
+import ast
+import json
+import os
+import sys
+
+req = json.load(sys.stdin)
+base = os.path.abspath(req.get("base", "."))
+files = req.get("files", [])
+warnings = []
+symbols = []
+
+def relpath(path):
+    return os.path.relpath(path, base).replace(os.sep, "/")
+
+def unparse(node, default="Any"):
+    if node is None:
+        return default
+    try:
+        return ast.unparse(node).strip()
+    except Exception:
+        return default
+
+def dotted(node):
+    if node is None:
+        return ""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        left = dotted(node.value)
+        return (left + "." if left else "") + node.attr
+    if isinstance(node, ast.Call):
+        return dotted(node.func)
+    if isinstance(node, ast.Subscript):
+        return dotted(node.value)
+    return unparse(node, "")
+
+def decorator_name(node):
+    return dotted(node) or unparse(node, "")
+
+def infer_type(value):
+    if isinstance(value, ast.Call):
+        name = dotted(value.func)
+        return name.split(".")[-1] if name else "Any"
+    if isinstance(value, ast.Constant):
+        if isinstance(value.value, str):
+            return "str"
+        if isinstance(value.value, bool):
+            return "bool"
+        if isinstance(value.value, int):
+            return "int"
+        if isinstance(value.value, float):
+            return "float"
+        if value.value is None:
+            return "None"
+    if isinstance(value, ast.List):
+        return "list"
+    if isinstance(value, ast.Dict):
+        return "dict"
+    if isinstance(value, ast.Set):
+        return "set"
+    if isinstance(value, ast.Tuple):
+        return "tuple"
+    return "Any"
+
+def default_values(args):
+    pos = list(args.posonlyargs) + list(args.args)
+    defaults = [None] * (len(pos) - len(args.defaults)) + list(args.defaults)
+    pairs = list(zip(pos, defaults))
+    pairs += [(arg, None) for arg in args.kwonlyargs]
+    return pairs
+
+def parse_params(fn):
+    out = []
+    for arg, default in default_values(fn.args):
+        out.append({
+            "name": arg.arg,
+            "type": unparse(arg.annotation, "Any"),
+            "default": unparse(default, None) if default is not None else None,
+        })
+    if fn.args.vararg is not None:
+        out.append({"name": "*" + fn.args.vararg.arg, "type": unparse(fn.args.vararg.annotation, "Any"), "default": None})
+    if fn.args.kwarg is not None:
+        out.append({"name": "**" + fn.args.kwarg.arg, "type": unparse(fn.args.kwarg.annotation, "Any"), "default": None})
+    return out
+
+def parse_method(fn):
+    return {
+        "name": fn.name,
+        "async": isinstance(fn, ast.AsyncFunctionDef),
+        "params": parse_params(fn),
+        "returns": unparse(fn.returns, "None"),
+        "decorators": [decorator_name(d) for d in fn.decorator_list],
+        "line": getattr(fn, "lineno", 1),
+    }
+
+def imported_symbols(tree):
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.asname or alias.name.split(".")[0])
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                local = alias.asname or alias.name
+                names.add(local)
+                names.add((module + "." + alias.name).strip("."))
+    return sorted(n for n in names if n)
+
+def collect_calls_and_refs(node):
+    calls = set()
+    refs = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            name = dotted(child.func)
+            if name:
+                calls.add(name)
+                calls.add(name.split(".")[-1])
+        elif isinstance(child, ast.Name):
+            refs.add(child.id)
+        elif isinstance(child, ast.Attribute):
+            refs.add(child.attr)
+            full = dotted(child)
+            if full:
+                refs.add(full)
+    return sorted(calls), sorted(refs)
+
+def field_put(fields, name, type_name):
+    if not name or name.startswith("_") or name in fields:
+        return
+    fields[name] = type_name or "Any"
+
+def parse_class(cls, path, file_imports):
+    fields = {}
+    methods = []
+    route_paths = set()
+    class_calls, class_refs = collect_calls_and_refs(cls)
+    for item in cls.body:
+        if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+            field_put(fields, item.target.id, unparse(item.annotation, "Any"))
+        elif isinstance(item, ast.Assign):
+            for target in item.targets:
+                if isinstance(target, ast.Name):
+                    field_put(fields, target.id, infer_type(item.value))
+        elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            methods.append(parse_method(item))
+            for dec in item.decorator_list:
+                name = decorator_name(dec)
+                if ".route" in name or name.endswith((".get", ".post", ".put", ".delete", ".patch")):
+                    route_paths.add(unparse(dec.args[0], "") if isinstance(dec, ast.Call) and dec.args else name)
+            for child in ast.walk(item):
+                if isinstance(child, ast.AnnAssign) and isinstance(child.target, ast.Attribute):
+                    if isinstance(child.target.value, ast.Name) and child.target.value.id == "self":
+                        field_put(fields, child.target.attr, unparse(child.annotation, "Any"))
+                elif isinstance(child, ast.Assign):
+                    for target in child.targets:
+                        if isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name) and target.value.id == "self":
+                            field_put(fields, target.attr, infer_type(child.value))
+    return {
+        "name": cls.name,
+        "symbolKind": "CLASS",
+        "bases": [unparse(base, "") for base in cls.bases],
+        "relPath": relpath(path),
+        "line": getattr(cls, "lineno", 1),
+        "decorators": [decorator_name(d) for d in cls.decorator_list],
+        "fields": [{"name": k, "type": v} for k, v in fields.items()],
+        "methods": methods,
+        "imports": file_imports,
+        "calls": class_calls,
+        "references": class_refs,
+        "routePaths": sorted(route_paths),
+    }
+
+def parse_function(fn, path, file_imports):
+    calls, refs = collect_calls_and_refs(fn)
+    route_paths = []
+    decorators = [decorator_name(d) for d in fn.decorator_list]
+    for dec in fn.decorator_list:
+        name = decorator_name(dec)
+        if ".route" in name or name.endswith((".get", ".post", ".put", ".delete", ".patch")):
+            route_paths.append(unparse(dec.args[0], "") if isinstance(dec, ast.Call) and dec.args else name)
+    return {
+        "name": fn.name,
+        "symbolKind": "FUNCTION",
+        "bases": [],
+        "relPath": relpath(path),
+        "line": getattr(fn, "lineno", 1),
+        "decorators": decorators,
+        "fields": [],
+        "methods": [parse_method(fn)],
+        "imports": file_imports,
+        "calls": calls,
+        "references": refs,
+        "routePaths": route_paths,
+    }
+
+for path in files:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+        tree = ast.parse(text, filename=path)
+    except SyntaxError as exc:
+        warnings.append(f"{relpath(path)}:{exc.lineno}: syntax error: {exc.msg}")
+        continue
+    except Exception as exc:
+        warnings.append(f"{relpath(path)}: could not parse: {exc}")
+        continue
+    file_imports = imported_symbols(tree)
+    for item in tree.body:
+        if isinstance(item, ast.ClassDef):
+            symbols.append(parse_class(item, path, file_imports))
+        elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            symbols.append(parse_function(item, path, file_imports))
+
+json.dump({"symbols": symbols, "warnings": warnings}, sys.stdout)
+"""
+}

--- a/src/main/kotlin/com/blueprint/ir/PythonIRExtractor.kt
+++ b/src/main/kotlin/com/blueprint/ir/PythonIRExtractor.kt
@@ -13,9 +13,8 @@ import java.nio.file.Paths
 /**
  * Recovers an ArchitectureIR from a Python project by walking .py files and
  * classifying classes / dataclasses / protocols into components, contracts,
- * and data types. v1 is regex-based; it preserves the existing hackathon
- * parser's latitude and adds decorator/import awareness, async detection,
- * and semantic classification.
+ * functions, and data types. Python's ast module is the primary parser; the
+ * old regex parser is retained only as a fallback when python is unavailable.
  */
 @Service(Service.Level.PROJECT)
 class PythonIRExtractor(private val project: Project) {
@@ -37,7 +36,13 @@ class PythonIRExtractor(private val project: Project) {
         return try {
             val context = project.service<PythonProjectAnalyzer>().analyze()
             val files = collectPythonFiles(base, context, maxDepth)
-            val parsed = preferGeneratedBlueprintClasses(files.flatMap { parseFile(base, it) }
+            val astParsed = PythonAstParser.parse(base, files)
+            val rawParsed = if (astParsed.usedAst) {
+                astParsed.symbols.map { it.toParsedClass() }
+            } else {
+                files.flatMap { parseFile(base, it) }
+            }
+            val parsed = preferGeneratedBlueprintClasses(rawParsed
                 .distinctBy { "${it.relPath}:${it.name}" }
             )
                 .sortedWith(compareBy<ParsedClass> { it.relPath }.thenBy { it.name })
@@ -51,7 +56,9 @@ class PythonIRExtractor(private val project: Project) {
 
             if (!context.isPythonLikely()) warnings += "Python project context is sparse; IR inferred from .py files only."
             if (files.isEmpty()) warnings += "No Python files were found in the current project."
-            if (parsed.isEmpty()) warnings += "No Python classes were found. Add a class or paste UML manually."
+            warnings += astParsed.warnings
+            if (!astParsed.usedAst) warnings += "Using legacy regex parser because AST extraction was not available."
+            if (parsed.isEmpty()) warnings += "No Python classes or module functions were found. Add code or paste UML manually."
 
             parsed.forEach { cls ->
                 val classified = classify(cls)
@@ -60,36 +67,7 @@ class PythonIRExtractor(private val project: Project) {
                 classified.dataType?.let { dataTypes += it }
             }
 
-            // Inheritance edges.
-            parsed.forEach { cls ->
-                cls.bases
-                    .filter { it in classNames && it != cls.name }
-                    .forEach { base ->
-                        edges += Edge(
-                            from = componentIdFor(cls),
-                            to = componentIdFor(base, parsed),
-                            toKind = EdgeTargetKind.COMPONENT,
-                            kind = EdgeKind.EXTENDS,
-                        )
-                    }
-            }
-            // Field-reference edges (contains / references).
-            parsed.forEach { cls ->
-                cls.fields.forEach { (fieldName, type) ->
-                    classNames
-                        .filter { other -> other != cls.name && type.referencesClass(other) }
-                        .forEach { other ->
-                            val label = if (fieldName.endsWith("s", ignoreCase = true)) EdgeKind.CONTAINS else EdgeKind.REFERENCES
-                            edges += Edge(
-                                from = componentIdFor(cls),
-                                to = componentIdFor(other, parsed),
-                                toKind = EdgeTargetKind.COMPONENT,
-                                kind = label,
-                                label = fieldName,
-                            )
-                        }
-                }
-            }
+            edges += recoverEdges(parsed, classNames)
 
             val ir = ArchitectureIR(
                 project = ProjectMeta(
@@ -132,6 +110,34 @@ class PythonIRExtractor(private val project: Project) {
         val ownership = Ownership(files = listOf(cls.relPath))
         val sourceRef = SourceRef(cls.relPath, cls.line)
         val componentId = componentIdFor(cls)
+
+        if (cls.symbolKind == ParsedSymbolKind.FUNCTION) {
+            val operation = cls.function?.toOperation()
+            val kind = when {
+                cls.relPath.contains("/tests/") || cls.relPath.startsWith("tests/") || cls.name.startsWith("test_") -> ComponentKind.TEST
+                decoratorNames.any { it.contains("click.command") || it.contains("click.group") || it.startsWith("cli.") } -> ComponentKind.CLI
+                decoratorNames.any { it.isRouteDecorator() } || cls.routePaths.isNotEmpty() -> ComponentKind.SERVICE
+                cls.name.endsWith("_job") || cls.name.endsWith("_task") || cls.name.endsWith("_worker") -> ComponentKind.JOB
+                else -> ComponentKind.SERVICE
+            }
+            val component = Component(
+                id = componentId,
+                name = cls.name,
+                kind = kind,
+                concurrency = concurrency,
+                ownership = ownership,
+                operations = listOfNotNull(operation),
+                requires = inferRequires(cls),
+                sourceRef = sourceRef,
+                description = buildString {
+                    append("Module function recovered from ${cls.relPath}")
+                    if (cls.routePaths.isNotEmpty()) append(" routes ${cls.routePaths.joinToString(", ")}")
+                },
+                opaqueAnnotations = collectOpaque(cls),
+                tags = setOf("function") + if (cls.routePaths.isNotEmpty()) setOf("route") else emptySet(),
+            )
+            return Classified(component, null, null)
+        }
 
         // Protocol / ABC → PORT + Contract(INTERFACE).
         val isProtocol = "Protocol" in baseSet || cls.bases.any { it.endsWith(".Protocol") }
@@ -202,6 +208,7 @@ class PythonIRExtractor(private val project: Project) {
         val kind = when {
             cls.relPath.contains("/tests/") || cls.relPath.startsWith("tests/") || cls.name.startsWith("Test") -> ComponentKind.TEST
             decoratorNames.any { it.contains("click.command") || it.contains("click.group") || it.startsWith("cli.") } -> ComponentKind.CLI
+            decoratorNames.any { it.isRouteDecorator() } || cls.routePaths.isNotEmpty() -> ComponentKind.SERVICE
             cls.name.endsWith("Registry") || cls.methods.any { it.name == "register" || it.name == "deregister" } -> ComponentKind.REGISTRY
             cls.name.endsWith("Adapter") || cls.name.endsWith("Client") ||
                 cls.name.endsWith("Repository") || cls.name.endsWith("Gateway") ||
@@ -234,11 +241,7 @@ class PythonIRExtractor(private val project: Project) {
     }
 
     private fun inferRequires(cls: ParsedClass): List<String> {
-        // v1: requires list is a best-effort. Constructor-injected typed params
-        // are captured as requires entries keyed by the type name. Wiring to
-        // real contract ids is up to IRToNodesCompiler when it resolves
-        // dependencies across components.
-        val init = cls.methods.firstOrNull { it.name == "__init__" } ?: return emptyList()
+        val init = cls.methods.firstOrNull { it.name == "__init__" } ?: cls.function ?: return emptyList()
         return init.params
             .filter { it.name != "self" }
             .mapNotNull { p ->
@@ -276,13 +279,24 @@ class PythonIRExtractor(private val project: Project) {
 
     private data class ParsedClass(
         val name: String,
+        val symbolKind: ParsedSymbolKind = ParsedSymbolKind.CLASS,
         val bases: List<String>,
         val relPath: String,
         val line: Int,
         val decorators: List<String>,
         val fields: LinkedHashMap<String, String> = linkedMapOf(),
         val methods: MutableList<ParsedMethod> = mutableListOf(),
+        val function: ParsedMethod? = null,
+        val imports: Set<String> = emptySet(),
+        val calls: Set<String> = emptySet(),
+        val references: Set<String> = emptySet(),
+        val routePaths: Set<String> = emptySet(),
     )
+
+    private enum class ParsedSymbolKind {
+        CLASS,
+        FUNCTION,
+    }
 
     private fun preferGeneratedBlueprintClasses(classes: List<ParsedClass>): List<ParsedClass> {
         val generatedClassNames = classes
@@ -353,6 +367,7 @@ class PythonIRExtractor(private val project: Project) {
                 classIndent = indentOf(header.groupValues[1])
                 current = ParsedClass(
                     name = header.groupValues[2],
+                    symbolKind = ParsedSymbolKind.CLASS,
                     bases = parseBases(header.groupValues.getOrElse(3) { "" }),
                     relPath = rel,
                     line = idx + 1,
@@ -478,6 +493,135 @@ class PythonIRExtractor(private val project: Project) {
 
     private fun String.referencesClass(className: String): Boolean =
         Regex("""\b${Regex.escape(className)}\b""").containsMatchIn(this)
+
+    private fun PythonAstParser.Symbol.toParsedClass(): ParsedClass {
+        val parsedMethods = methods.map { it.toParsedMethod() }.toMutableList()
+        val functionMethod = parsedMethods.firstOrNull()
+        return ParsedClass(
+            name = name,
+            symbolKind = if (symbolKind == "FUNCTION") ParsedSymbolKind.FUNCTION else ParsedSymbolKind.CLASS,
+            bases = bases.map { it.substringBefore("[").substringAfterLast(".") }.filter { it.isNotBlank() }.distinct(),
+            relPath = relPath,
+            line = line,
+            decorators = decorators.filter { it.isNotBlank() },
+            fields = fields.fold(linkedMapOf()) { acc, field ->
+                if (field.name.isNotBlank() && !field.name.startsWith("_") && field.name !in IGNORED_FIELDS) {
+                    acc.putIfAbsent(field.name, field.type.ifBlank { "Any" })
+                }
+                acc
+            },
+            methods = if (symbolKind == "FUNCTION") mutableListOf() else parsedMethods,
+            function = if (symbolKind == "FUNCTION") functionMethod else null,
+            imports = imports.filter { it.isNotBlank() }.toSet(),
+            calls = calls.filter { it.isNotBlank() }.toSet(),
+            references = references.filter { it.isNotBlank() }.toSet(),
+            routePaths = routePaths.filter { it.isNotBlank() }.toSet(),
+        )
+    }
+
+    private fun PythonAstParser.MethodDecl.toParsedMethod(): ParsedMethod =
+        ParsedMethod(
+            name = name,
+            async = async,
+            params = params.map { ParsedParam(it.name, it.type, it.default) },
+            returns = returns.ifBlank { "None" },
+            decorators = decorators,
+            line = line,
+        )
+
+    private fun recoverEdges(parsed: List<ParsedClass>, symbolNames: Set<String>): List<Edge> {
+        val edges = mutableListOf<Edge>()
+
+        fun targetId(name: String): String? {
+            val simple = name.substringBefore("[").substringAfterLast(".").trim()
+            if (simple.isBlank() || simple !in symbolNames) return null
+            val target = parsed.firstOrNull { it.name == simple } ?: return null
+            return componentIdFor(target)
+        }
+
+        fun addEdge(
+            source: ParsedClass,
+            targetName: String,
+            kind: EdgeKind,
+            label: String,
+            evidence: String,
+            confidence: Double,
+        ) {
+            val target = targetId(targetName) ?: return
+            val from = componentIdFor(source)
+            if (target == from) return
+            edges += Edge(
+                from = from,
+                to = target,
+                toKind = EdgeTargetKind.COMPONENT,
+                kind = kind,
+                label = label,
+                sourceRef = SourceRef(source.relPath, source.line),
+                evidence = evidence,
+                confidence = confidence,
+            )
+        }
+
+        parsed.forEach { cls ->
+            cls.bases.forEach { base ->
+                addEdge(cls, base, EdgeKind.EXTENDS, "extends", "base class: $base", 1.0)
+            }
+
+            cls.fields.forEach { (fieldName, type) ->
+                symbolNames
+                    .filter { other -> other != cls.name && type.referencesClass(other) }
+                    .forEach { other ->
+                        val kind = if (fieldName.endsWith("s", ignoreCase = true)) EdgeKind.CONTAINS else EdgeKind.REFERENCES
+                        addEdge(cls, other, kind, "$fieldName field", "field annotation/value: $fieldName -> $type", 0.95)
+                    }
+            }
+
+            val callable = cls.methods.firstOrNull { it.name == "__init__" } ?: cls.function
+            callable?.params.orEmpty()
+                .filter { it.name != "self" && it.name != "cls" }
+                .forEach { param ->
+                    addEdge(
+                        cls,
+                        param.type,
+                        EdgeKind.REFERENCES,
+                        "${param.name} constructor param",
+                        "typed parameter: ${param.name}: ${param.type}",
+                        0.9,
+                    )
+                }
+
+            cls.imports.forEach { imported ->
+                addEdge(cls, imported, EdgeKind.REFERENCES, "import", "imported symbol: $imported", 0.65)
+            }
+
+            cls.calls.forEach { call ->
+                val label = if (cls.isTestSymbol()) "tests" else "calls"
+                addEdge(cls, call, EdgeKind.CALLS, label, "call expression: $call", 0.8)
+            }
+
+            cls.references.forEach { ref ->
+                if (ref.firstOrNull()?.isUpperCase() == true) {
+                    addEdge(cls, ref, EdgeKind.REFERENCES, "references", "name reference: $ref", 0.6)
+                }
+            }
+        }
+
+        return edges
+            .groupBy { listOf(it.from, it.to, it.kind.name, it.label).joinToString("|") }
+            .values
+            .map { it.first() }
+    }
+
+    private fun ParsedClass.isTestSymbol(): Boolean =
+        relPath.startsWith("tests/") || relPath.contains("/tests/") || name.startsWith("Test") || name.startsWith("test_")
+
+    private fun String.isRouteDecorator(): Boolean =
+        contains(".route") ||
+            endsWith(".get") ||
+            endsWith(".post") ||
+            endsWith(".put") ||
+            endsWith(".delete") ||
+            endsWith(".patch")
 
     // ---------- filesystem ----------
 

--- a/src/main/kotlin/com/blueprint/ir/Schema.kt
+++ b/src/main/kotlin/com/blueprint/ir/Schema.kt
@@ -179,6 +179,9 @@ data class Edge(
     val toKind: EdgeTargetKind = EdgeTargetKind.COMPONENT,
     val kind: EdgeKind = EdgeKind.CALLS,
     val label: String = "",
+    val sourceRef: SourceRef? = null,
+    val evidence: String = "",
+    val confidence: Double = 1.0,
 )
 
 enum class EdgeKind {

--- a/src/test/kotlin/com/blueprint/ir/IRPipelineTest.kt
+++ b/src/test/kotlin/com/blueprint/ir/IRPipelineTest.kt
@@ -153,7 +153,7 @@ class IRPipelineTest {
         assertTrue("must start with classDiagram", mermaid.startsWith("classDiagram"))
         assertTrue("must mention Invite", mermaid.contains("class Invite"))
         assertTrue("must mention InvitePolicy", mermaid.contains("class InvitePolicy"))
-        assertTrue("must render a contains edge", mermaid.contains("contains"))
+        assertTrue("must render relationship edge label", mermaid.contains("belongs to"))
     }
 
     @Test
@@ -206,7 +206,16 @@ class IRPipelineTest {
                 ),
             ),
             edges = listOf(
-                Edge("payments.service", "payments.gateway", EdgeTargetKind.COMPONENT, EdgeKind.CALLS, "authorize"),
+                Edge(
+                    "payments.service",
+                    "payments.gateway",
+                    EdgeTargetKind.COMPONENT,
+                    EdgeKind.CALLS,
+                    "authorize",
+                    SourceRef("payments/service.py", 42),
+                    "call expression: gateway.authorize",
+                    0.8,
+                ),
             ),
             coverage = RecoveryCoverage(componentsRecovered = 1, componentsTotal = 1, contractsRecovered = 1),
         )
@@ -224,6 +233,8 @@ class IRPipelineTest {
         assertEquals(1, c.opaqueAnnotations.size)
         assertEquals(Concurrency.ASYNC, back.contracts.single().operations.single().concurrency)
         assertEquals(EdgeKind.CALLS, back.edges.single().kind)
+        assertEquals("call expression: gateway.authorize", back.edges.single().evidence)
+        assertEquals(0.8, back.edges.single().confidence, 0.001)
     }
 
     // ---- Empty IR guard ----

--- a/src/test/kotlin/com/blueprint/ir/PythonAstParserTest.kt
+++ b/src/test/kotlin/com/blueprint/ir/PythonAstParserTest.kt
@@ -1,0 +1,74 @@
+package com.blueprint.ir
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.nio.file.Files
+
+class PythonAstParserTest {
+    @Test
+    fun `ast parser recovers classes module functions imports calls and multiline signatures`() {
+        val dir = Files.createTempDirectory("blueprint-python-ast")
+        val app = dir.resolve("app")
+        Files.createDirectories(app)
+        val models = app.resolve("models.py")
+        val service = app.resolve("service.py")
+
+        Files.writeString(
+            models,
+            """
+            from dataclasses import dataclass
+            from typing import Protocol
+
+            @dataclass
+            class User:
+                id: str
+                email: str
+
+            class InviteRepository(Protocol):
+                def save(self, invite: "Invite") -> None:
+                    ...
+
+            @dataclass
+            class Invite:
+                id: str
+                user: User
+                created_at: str
+            """.trimIndent(),
+        )
+        Files.writeString(
+            service,
+            """
+            from .models import Invite, InviteRepository, User
+
+            def create_invite(
+                repo: InviteRepository,
+                user: User,
+            ) -> Invite:
+                invite = Invite(id="i1", user=user, created_at="now")
+                repo.save(invite)
+                return invite
+            """.trimIndent(),
+        )
+
+        val result = PythonAstParser.parse(dir, listOf(models, service))
+        assumeTrue("python3 is required for this AST parser test", result.usedAst)
+
+        val names = result.symbols.map { it.name }.toSet()
+        assertTrue(names.containsAll(setOf("User", "Invite", "InviteRepository", "create_invite")))
+
+        val invite = result.symbols.single { it.name == "Invite" }
+        assertEquals("CLASS", invite.symbolKind)
+        assertEquals("app/models.py", invite.relPath)
+        assertTrue(invite.decorators.contains("dataclass"))
+        assertTrue(invite.fields.any { it.name == "user" && it.type == "User" })
+
+        val createInvite = result.symbols.single { it.name == "create_invite" }
+        assertEquals("FUNCTION", createInvite.symbolKind)
+        assertTrue(createInvite.imports.contains("InviteRepository"))
+        assertTrue(createInvite.calls.contains("Invite"))
+        assertTrue(createInvite.methods.single().params.any { it.name == "repo" && it.type == "InviteRepository" })
+        assertEquals("Invite", createInvite.methods.single().returns)
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the regex-first Python recovery path with a Python ast-backed parser, keeping the legacy regex parser only as a fallback when python is unavailable.
- Recover classes, module-level functions, decorators, imports, multiline signatures, fields, methods, calls, references, and route decorators.
- Add source-backed relationship metadata on IR edges: source ref, evidence, and confidence.
- Render specific relationship labels in Mermaid instead of only generic edge kinds.
- Add AST parser tests and extend IR serialization tests for edge evidence/confidence.

## Tests
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew test --no-daemon

Fixes #3
Fixes #4