### PR TITLE
Fix #8: Enforce apply freshness before UML refresh

### DIFF
--- a/src/main/kotlin/com/blueprint/service/ApplyChangesService.kt
+++ b/src/main/kotlin/com/blueprint/service/ApplyChangesService.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.charset.StandardCharsets
 
@@ -68,13 +69,19 @@ class ApplyChangesService(private val project: Project) {
                     continue
                 }
                 try {
+                    val before = snapshot(base, rel)
+                    val preflight = PatchFreshness.verify(patch, before, before)
+                    if (preflight.matchesPatch && !preflight.changedDisk) {
+                        skipped += rel to preflight.reason
+                        continue
+                    }
                     applyOne(basePath, rel, patch)
-                    val expected = normalizeContent(if (patch.action.equals("delete", ignoreCase = true)) "" else patch.content)
-                    val actual = normalizeContent(readCurrentContent(rel))
-                    if (actual == expected) {
+                    val after = snapshot(base, rel)
+                    val verification = PatchFreshness.verify(patch, before, after)
+                    if (verification.matchesPatch && verification.changedDisk) {
                         applied += rel
                     } else {
-                        skipped += rel to "disk content did not match applied patch"
+                        skipped += rel to verification.reason.ifBlank { "patch did not change disk" }
                     }
                 } catch (t: Throwable) {
                     log.warn("Failed to apply $rel", t)
@@ -144,6 +151,16 @@ class ApplyChangesService(private val project: Project) {
         return Files.readString(target, StandardCharsets.UTF_8)
     }
 
-    private fun normalizeContent(text: String): String =
-        text.replace("\r\n", "\n").trimEnd()
+    fun readCurrentSnapshot(relPath: String): DiskSnapshot {
+        val basePath = project.basePath ?: return DiskSnapshot(exists = false)
+        val rel = FileScope.normalizeRelativePath(relPath) ?: return DiskSnapshot(exists = false)
+        val base = Paths.get(basePath).normalize()
+        return snapshot(base, rel)
+    }
+
+    private fun snapshot(base: Path, rel: String): DiskSnapshot {
+        val target = base.resolve(rel).normalize()
+        if (!target.startsWith(base) || !Files.isRegularFile(target)) return DiskSnapshot(exists = false)
+        return DiskSnapshot(exists = true, content = Files.readString(target, StandardCharsets.UTF_8))
+    }
 }

--- a/src/main/kotlin/com/blueprint/service/PatchFreshness.kt
+++ b/src/main/kotlin/com/blueprint/service/PatchFreshness.kt
@@ -1,0 +1,47 @@
+package com.blueprint.service
+
+import com.blueprint.model.Patch
+
+data class DiskSnapshot(
+    val exists: Boolean,
+    val content: String = "",
+)
+
+data class PatchFreshnessResult(
+    val matchesPatch: Boolean,
+    val changedDisk: Boolean,
+    val reason: String = "",
+)
+
+object PatchFreshness {
+    fun verify(patch: Patch, before: DiskSnapshot, after: DiskSnapshot): PatchFreshnessResult {
+        val action = patch.action.lowercase().ifBlank { "update" }
+        val expected = normalize(if (action == "delete") "" else patch.content)
+
+        if (action == "delete") {
+            return when {
+                !before.exists ->
+                    PatchFreshnessResult(matchesPatch = !after.exists, changedDisk = false, reason = "file already absent")
+                after.exists ->
+                    PatchFreshnessResult(matchesPatch = false, changedDisk = false, reason = "file still exists after delete")
+                else ->
+                    PatchFreshnessResult(matchesPatch = true, changedDisk = true)
+            }
+        }
+
+        val beforeMatches = before.exists && normalize(before.content) == expected
+        if (beforeMatches && after.exists && normalize(after.content) == expected) {
+            return PatchFreshnessResult(matchesPatch = true, changedDisk = false, reason = "disk already matched patch")
+        }
+        if (!after.exists) {
+            return PatchFreshnessResult(matchesPatch = false, changedDisk = false, reason = "file missing after apply")
+        }
+        if (normalize(after.content) != expected) {
+            return PatchFreshnessResult(matchesPatch = false, changedDisk = false, reason = "disk content did not match applied patch")
+        }
+        return PatchFreshnessResult(matchesPatch = true, changedDisk = true)
+    }
+
+    fun normalize(text: String): String =
+        text.replace("\r\n", "\n").trimEnd()
+}

--- a/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
+++ b/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
@@ -16,6 +16,7 @@ import com.blueprint.service.JsonExtractor
 import com.blueprint.service.NodeExecutionService
 import com.blueprint.service.NodePlanningService
 import com.blueprint.service.NodeRegistry
+import com.blueprint.service.PatchFreshness
 import com.blueprint.service.PythonProjectAnalyzer
 import com.blueprint.service.PythonUmlGenerator
 import com.blueprint.service.ReviewService
@@ -1199,6 +1200,10 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         if (!confirmDiscardPendingUmlEdits()) return
         status("Generating UML from Python project...")
         val generated = project.service<PythonUmlGenerator>().generate()
+        loadGeneratedUml(generated)
+    }
+
+    private fun loadGeneratedUml(generated: PythonUmlGenerator.GeneratedUml) {
         setUmlEditorText(generated.text, pendingEdits = false)
         umlStatusLabel.text = "UML: ${generated.classCount} class(es), ${generated.relationshipCount} relationship(s), ${generated.filesScanned} file(s) scanned."
         graphArea.text = buildString {
@@ -1434,13 +1439,11 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
     }
 
     private fun patchChangesDisk(patch: Patch): Boolean {
-        val current = normalizeContent(project.service<ApplyChangesService>().readCurrentContent(patch.path))
-        val proposed = normalizeContent(if (patch.action.equals("delete", ignoreCase = true)) "" else patch.content)
-        return current != proposed
+        val before = project.service<ApplyChangesService>().readCurrentSnapshot(patch.path)
+        val expectedExists = !patch.action.equals("delete", ignoreCase = true)
+        val proposed = PatchFreshness.normalize(if (expectedExists) patch.content else "")
+        return before.exists != expectedExists || PatchFreshness.normalize(before.content) != proposed
     }
-
-    private fun normalizeContent(text: String): String =
-        text.replace("\r\n", "\n").trimEnd()
 
     private fun importUmlText(text: String, sourceLabel: String) {
         if (text.isBlank()) {
@@ -2047,6 +2050,12 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         }
         if (n.executionStatus == ExecutionStatus.APPLIED) {
             umlHasPendingEdits = false
+            val generated = project.service<PythonUmlGenerator>().generate()
+            loadGeneratedUml(generated)
+            logActivity(
+                "Freshness verified after apply: refreshed UML from disk with " +
+                    "${generated.classCount} class(es), ${generated.relationshipCount} relationship(s)."
+            )
         }
         registry.update(n)
         refreshArtifactSummary()

--- a/src/test/kotlin/com/blueprint/ir/FreshRefreshRoundTripTest.kt
+++ b/src/test/kotlin/com/blueprint/ir/FreshRefreshRoundTripTest.kt
@@ -1,0 +1,64 @@
+package com.blueprint.ir
+
+import com.blueprint.model.Patch
+import com.blueprint.service.DiskSnapshot
+import com.blueprint.service.PatchFreshness
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.nio.file.Files
+
+class FreshRefreshRoundTripTest {
+    @Test
+    fun `after disk changes ast refresh sees newly applied UML fields and classes`() {
+        val dir = Files.createTempDirectory("blueprint-fresh-refresh")
+        val models = dir.resolve("models.py")
+        Files.writeString(
+            models,
+            """
+            from dataclasses import dataclass
+
+            @dataclass
+            class Invite:
+                id: str
+                email: str
+            """.trimIndent(),
+        )
+
+        val refreshedBefore = PythonAstParser.parse(dir, listOf(models))
+        assumeTrue("python3 is required for this refresh regression", refreshedBefore.usedAst)
+        assertTrue(refreshedBefore.symbols.single { it.name == "Invite" }.fields.none { it.name == "expires_at" })
+
+        val updatedContent = """
+            from dataclasses import dataclass
+            from datetime import datetime
+
+            @dataclass
+            class Invite:
+                id: str
+                email: str
+                expires_at: datetime
+
+            @dataclass
+            class InviteAuditLog:
+                actor_email: str
+                action: str
+                created_at: datetime
+                invite: Invite
+        """.trimIndent()
+        val patch = Patch(path = "models.py", action = "update", content = updatedContent)
+        val before = DiskSnapshot(exists = true, content = Files.readString(models))
+        Files.writeString(models, updatedContent)
+        val after = DiskSnapshot(exists = true, content = Files.readString(models))
+        val verification = PatchFreshness.verify(patch, before, after)
+        assertTrue(verification.matchesPatch)
+        assertTrue(verification.changedDisk)
+
+        val refreshedAfter = PythonAstParser.parse(dir, listOf(models))
+        assumeTrue("python3 is required for this refresh regression", refreshedAfter.usedAst)
+        val invite = refreshedAfter.symbols.single { it.name == "Invite" }
+        val auditLog = refreshedAfter.symbols.single { it.name == "InviteAuditLog" }
+        assertTrue(invite.fields.any { it.name == "expires_at" && it.type == "datetime" })
+        assertTrue(auditLog.fields.any { it.name == "invite" && it.type == "Invite" })
+    }
+}

--- a/src/test/kotlin/com/blueprint/service/PatchFreshnessTest.kt
+++ b/src/test/kotlin/com/blueprint/service/PatchFreshnessTest.kt
@@ -1,0 +1,59 @@
+package com.blueprint.service
+
+import com.blueprint.model.Patch
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PatchFreshnessTest {
+    @Test
+    fun `update must match patch and actually change disk`() {
+        val patch = Patch(path = "models.py", action = "update", content = "class Invite:\n    pass\n")
+
+        val changed = PatchFreshness.verify(
+            patch,
+            before = DiskSnapshot(exists = true, content = "class Invite:\n    id: str\n"),
+            after = DiskSnapshot(exists = true, content = "class Invite:\n    pass\n"),
+        )
+        assertTrue(changed.matchesPatch)
+        assertTrue(changed.changedDisk)
+
+        val stale = PatchFreshness.verify(
+            patch,
+            before = DiskSnapshot(exists = true, content = "class Invite:\n    pass\n"),
+            after = DiskSnapshot(exists = true, content = "class Invite:\n    pass\n"),
+        )
+        assertTrue(stale.matchesPatch)
+        assertFalse(stale.changedDisk)
+        assertTrue(stale.reason.contains("already matched"))
+    }
+
+    @Test
+    fun `create and delete account for file existence not just content`() {
+        val createEmpty = Patch(path = "empty.py", action = "create", content = "")
+        val created = PatchFreshness.verify(
+            createEmpty,
+            before = DiskSnapshot(exists = false),
+            after = DiskSnapshot(exists = true, content = ""),
+        )
+        assertTrue(created.matchesPatch)
+        assertTrue(created.changedDisk)
+
+        val deleteEmpty = Patch(path = "empty.py", action = "delete", content = "")
+        val deleted = PatchFreshness.verify(
+            deleteEmpty,
+            before = DiskSnapshot(exists = true, content = ""),
+            after = DiskSnapshot(exists = false),
+        )
+        assertTrue(deleted.matchesPatch)
+        assertTrue(deleted.changedDisk)
+
+        val alreadyAbsent = PatchFreshness.verify(
+            deleteEmpty,
+            before = DiskSnapshot(exists = false),
+            after = DiskSnapshot(exists = false),
+        )
+        assertTrue(alreadyAbsent.matchesPatch)
+        assertFalse(alreadyAbsent.changedDisk)
+    }
+}


### PR DESCRIPTION
## Summary
- Add patch freshness verification that checks both content and file existence before/after apply.
- Treat already-applied/no-op patches as skipped instead of marking nodes applied.
- Fix diff filtering so create/delete of empty files still counts as a real disk change.
- Automatically refresh UML from disk after a fully successful apply so the canvas/IR reflects the current codebase.
- Add regression tests for stale/no-op patches and fresh disk refresh seeing newly applied model fields/classes.

## Tests
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew test --no-daemon

Fixes #8