### PR TITLE
Fix #7: Add source click-through from code map

### DIFF
--- a/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
+++ b/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
@@ -22,13 +22,16 @@ import com.blueprint.service.PythonUmlGenerator
 import com.blueprint.service.ReviewService
 import com.blueprint.service.UmlImportService
 import com.intellij.openapi.components.service
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
+import java.io.File
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Component
@@ -575,6 +578,9 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
     private fun buildUi() {
         miniGraph.onNodeSelected = { nodeId ->
             selectNodeFromGraph(nodeId)
+        }
+        miniGraph.onNodeOpenSource = { node ->
+            openGraphSource(node)
         }
         filterCombo.addActionListener {
             refreshList()
@@ -2169,6 +2175,57 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         logActivity("Graph selected ${node.title.ifBlank { node.id.take(8) }} (${node.id.take(8)}).")
     }
 
+    private fun openGraphSource(node: MiniGraphPanel.NodeView) {
+        val sourcePath = node.sourcePath.ifBlank {
+            status("No source mapping for ${node.title}.")
+            Messages.showInfoMessage(
+                project,
+                "${node.title} is not mapped to a source file yet.",
+                "Blueprint - Source Not Mapped",
+            )
+            return
+        }
+        val sourceFile = resolveProjectFile(sourcePath)
+        if (!sourceFile.isFile) {
+            status("Could not find source: $sourcePath")
+            Messages.showWarningDialog(
+                project,
+                "Could not find source file:\n$sourcePath",
+                "Blueprint - Source Not Found",
+            )
+            return
+        }
+        val virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(sourceFile)
+        if (virtualFile == null) {
+            status("Could not open source: ${sourceFile.path}")
+            Messages.showWarningDialog(
+                project,
+                "Could not open source file:\n${sourceFile.path}",
+                "Blueprint - Source Not Found",
+            )
+            return
+        }
+        val zeroBasedLine = (node.sourceLine ?: 1).coerceAtLeast(1) - 1
+        OpenFileDescriptor(project, virtualFile, zeroBasedLine, 0).navigate(true)
+        selectedCanvasId = node.id
+        status("Opened source: ${node.sourceDescriptionForStatus()}")
+        logActivity("Opened source for ${node.title}: ${node.sourceDescriptionForStatus()}")
+    }
+
+    private fun resolveProjectFile(path: String): File {
+        val raw = File(path)
+        if (raw.isAbsolute) return raw
+        val base = project.basePath ?: return raw
+        return File(base, path)
+    }
+
+    private fun MiniGraphPanel.NodeView.sourceDescriptionForStatus(): String =
+        when {
+            source.isNotBlank() -> source
+            sourceLine != null -> "$sourcePath:$sourceLine"
+            else -> sourcePath
+        }
+
     private fun setUmlEditorText(text: String, pendingEdits: Boolean) {
         suppressUmlDocumentEvents = true
         try {
@@ -2327,6 +2384,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
                 origin = MiniGraphPanel.NodeOrigin.WORKFLOW,
                 kind = node.type.name.lowercase(),
                 source = node.fileScope.paths.firstOrNull().orEmpty(),
+                sourcePath = node.fileScope.paths.firstOrNull().orEmpty(),
                 preview = readiness?.let { if (it.ready) "ready to run" else it.reasons.firstOrNull().orEmpty() }.orEmpty(),
                 relationshipHint = if (node.dependencies.isEmpty()) "" else "depends on ${node.dependencies.size} node(s)",
             )

--- a/src/main/kotlin/com/blueprint/ui/CodeMapProjection.kt
+++ b/src/main/kotlin/com/blueprint/ui/CodeMapProjection.kt
@@ -57,6 +57,7 @@ object CodeMapProjection {
             .sortedWith(compareBy<Component>({ waveOf(it.id) }, { it.ownership.files.firstOrNull() ?: "" }, { it.name }))
             .map { component ->
                 val workflow = workflowByComponentId[component.id]
+                val sourceTarget = component.sourceTarget()
                 MiniGraphPanel.NodeView(
                     id = component.id,
                     title = component.name,
@@ -69,7 +70,9 @@ object CodeMapProjection {
                     detail = detailFor(component),
                     origin = MiniGraphPanel.NodeOrigin.CODE,
                     kind = component.kind.codeMapLabel(),
-                    source = component.primarySource(),
+                    source = sourceTarget.label,
+                    sourcePath = sourceTarget.path,
+                    sourceLine = sourceTarget.line,
                     preview = previewFor(component),
                     fields = component.fields.take(3).map { it.cardLabel() },
                     fieldOverflowCount = (component.fields.size - 3).coerceAtLeast(0),
@@ -112,9 +115,20 @@ object CodeMapProjection {
     }
 
     private fun Component.primarySource(): String =
-        sourceRef?.let { ref -> ref.line?.let { "${ref.path}:$it" } ?: ref.path }
-            ?: ownership.files.firstOrNull()
-            .orEmpty()
+        sourceTarget().label
+
+    private fun Component.sourceTarget(): SourceTarget {
+        val ref = sourceRef
+        val fallbackPath = ownership.files.firstOrNull().orEmpty()
+        val path = ref?.path?.takeIf { it.isNotBlank() } ?: fallbackPath
+        val line = ref?.line
+        val label = when {
+            path.isBlank() -> ""
+            line != null -> "$path:$line"
+            else -> path
+        }
+        return SourceTarget(path = path, line = line, label = label)
+    }
 
     private fun Field.cardLabel(): String =
         buildString {
@@ -150,4 +164,10 @@ object CodeMapProjection {
 
     private fun EdgeKind.codeMapLabel(): String =
         name.lowercase().replace('_', ' ')
+
+    private data class SourceTarget(
+        val path: String,
+        val line: Int?,
+        val label: String,
+    )
 }

--- a/src/main/kotlin/com/blueprint/ui/MiniGraphPanel.kt
+++ b/src/main/kotlin/com/blueprint/ui/MiniGraphPanel.kt
@@ -59,6 +59,8 @@ class MiniGraphPanel : JPanel() {
         val origin: NodeOrigin = NodeOrigin.WORKFLOW,
         val kind: String = "",
         val source: String = "",
+        val sourcePath: String = "",
+        val sourceLine: Int? = null,
         val preview: String = "",
         val fields: List<String> = emptyList(),
         val fieldOverflowCount: Int = 0,
@@ -69,7 +71,9 @@ class MiniGraphPanel : JPanel() {
 
     private var nodes: List<NodeView> = emptyList()
     private var cards: Map<String, RoundRectangle2D.Float> = emptyMap()
+    private var sourceBadges: Map<String, RoundRectangle2D.Float> = emptyMap()
     var onNodeSelected: ((String) -> Unit)? = null
+    var onNodeOpenSource: ((NodeView) -> Unit)? = null
 
     init {
         preferredSize = Dimension(900, 420)
@@ -79,6 +83,15 @@ class MiniGraphPanel : JPanel() {
         addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
                 nodeAt(e.point)?.let { node ->
+                    if (e.clickCount >= 2 || sourceBadgeAt(e.point)?.id == node.id) {
+                        if (node.hasSourceTarget()) {
+                            onNodeOpenSource?.invoke(node)
+                        } else {
+                            onNodeSelected?.invoke(node.id)
+                        }
+                        repaint()
+                        return
+                    }
                     onNodeSelected?.invoke(node.id)
                     repaint()
                 }
@@ -86,7 +99,7 @@ class MiniGraphPanel : JPanel() {
         })
         addMouseMotionListener(object : MouseMotionAdapter() {
             override fun mouseMoved(e: MouseEvent) {
-                cursor = if (nodeAt(e.point) != null) {
+                cursor = if (nodeAt(e.point) != null || sourceBadgeAt(e.point) != null) {
                     Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
                 } else {
                     Cursor.getDefaultCursor()
@@ -107,7 +120,8 @@ class MiniGraphPanel : JPanel() {
                 "Origin: ${node.origin.label()}<br/>" +
                 "Status: ${node.status}<br/>" +
                 node.kind.takeIf { it.isNotBlank() }?.let { "Kind: ${escape(it)}<br/>" }.orEmpty() +
-                node.source.takeIf { it.isNotBlank() }?.let { "Source: ${escape(it)}<br/>" }.orEmpty() +
+                "Source: ${escape(node.sourceDescription())}<br/>" +
+                node.hasSourceTarget().takeIf { it }?.let { "Double-click to open source.<br/>" }.orEmpty() +
                 "Wave: ${node.wave}<br/>" +
                 node.summaryLine("Fields", node.fields, node.fieldOverflowCount).takeIf { it.isNotBlank() }
                     ?.let { "${escape(it)}<br/>" }.orEmpty() +
@@ -136,6 +150,7 @@ class MiniGraphPanel : JPanel() {
             g.font = font.deriveFont(Font.PLAIN, 13f)
             g.drawString("Click Abstract Code to UML to draw this project as architecture.", 24, 38)
             cards = emptyMap()
+            sourceBadges = emptyMap()
             return
         }
 
@@ -148,6 +163,7 @@ class MiniGraphPanel : JPanel() {
         val startX = 24f
         val startY = 46f
         val localCards = mutableMapOf<String, RoundRectangle2D.Float>()
+        val localSourceBadges = mutableMapOf<String, RoundRectangle2D.Float>()
 
         waves.entries.forEachIndexed { waveIndex, (wave, waveNodes) ->
             val x = startX + waveIndex * (cardW + gapX)
@@ -227,6 +243,11 @@ class MiniGraphPanel : JPanel() {
                 }
             }
 
+            if (node.hasSourceTarget()) {
+                val badge = paintSourceBadge(g, card, textLeft)
+                localSourceBadges[node.id] = badge
+            }
+
             paintStatusBadge(g, node, card)
 
             g.color = if (node.selected) Theme.Accent else Theme.Muted
@@ -237,6 +258,7 @@ class MiniGraphPanel : JPanel() {
         }
 
         cards = localCards
+        sourceBadges = localSourceBadges
     }
 
     private fun paintDotGrid(g: Graphics2D) {
@@ -256,6 +278,25 @@ class MiniGraphPanel : JPanel() {
     private fun nodeAt(point: Point): NodeView? {
         val id = cards.entries.firstOrNull { (_, card) -> card.contains(point) }?.key ?: return null
         return nodes.firstOrNull { it.id == id }
+    }
+
+    private fun sourceBadgeAt(point: Point): NodeView? {
+        val id = sourceBadges.entries.firstOrNull { (_, badge) -> badge.contains(point) }?.key ?: return null
+        return nodes.firstOrNull { it.id == id }
+    }
+
+    private fun paintSourceBadge(g: Graphics2D, card: RoundRectangle2D.Float, textLeft: Int): RoundRectangle2D.Float {
+        val label = "src"
+        val width = 36
+        val x = textLeft
+        val y = (card.y + card.height - 22).toInt()
+        val badge = RoundRectangle2D.Float(x.toFloat(), y.toFloat(), width.toFloat(), 16f, 8f, 8f)
+        g.color = Theme.AccentSurface
+        g.fill(badge)
+        g.color = Theme.Accent
+        g.font = font.deriveFont(Font.PLAIN, 10f)
+        g.drawString(label, x + 9, y + 12)
+        return badge
     }
 
     private fun paintStatusBadge(g: Graphics2D, node: NodeView, card: RoundRectangle2D.Float) {
@@ -359,9 +400,13 @@ class MiniGraphPanel : JPanel() {
 
     private fun NodeView.metadataLine(): String =
         when (origin) {
-            NodeOrigin.CODE -> listOf(kind.ifBlank { "code" }, source).filter { it.isNotBlank() }.joinToString("  ")
-            NodeOrigin.PROPOSED_UML -> listOf(kind.ifBlank { "UML proposal" }, "editable").joinToString("  ")
-            NodeOrigin.WORKFLOW -> listOf(kind.ifBlank { "workflow" }, id.take(8)).joinToString("  ")
+            NodeOrigin.CODE -> listOf(kind.ifBlank { "code" }, source.ifBlank { "source: not mapped" }).joinToString("  ")
+            NodeOrigin.PROPOSED_UML -> listOf(kind.ifBlank { "UML proposal" }, "proposed, not mapped").joinToString("  ")
+            NodeOrigin.WORKFLOW -> listOf(
+                kind.ifBlank { "workflow" },
+                source.ifBlank { "generated, not mapped" },
+                id.take(8),
+            ).joinToString("  ")
         }
 
     private fun NodeView.summaryLine(label: String, values: List<String>, overflow: Int): String {
@@ -372,6 +417,19 @@ class MiniGraphPanel : JPanel() {
 
     private fun NodeView.hasRichFacts(): Boolean =
         source.isNotBlank() || fields.isNotEmpty() || methods.isNotEmpty() || relationshipHint.isNotBlank()
+
+    private fun NodeView.hasSourceTarget(): Boolean =
+        sourcePath.isNotBlank()
+
+    private fun NodeView.sourceDescription(): String =
+        when {
+            source.isNotBlank() -> source
+            sourcePath.isNotBlank() && sourceLine != null -> "$sourcePath:$sourceLine"
+            sourcePath.isNotBlank() -> sourcePath
+            origin == NodeOrigin.PROPOSED_UML -> "proposed UML, not mapped to source yet"
+            origin == NodeOrigin.WORKFLOW -> "generated workflow node, not mapped to source yet"
+            else -> "not mapped to source"
+        }
 
     private fun NodeOrigin.label(): String =
         when (this) {

--- a/src/test/kotlin/com/blueprint/ui/CodeMapProjectionTest.kt
+++ b/src/test/kotlin/com/blueprint/ui/CodeMapProjectionTest.kt
@@ -10,6 +10,7 @@ import com.blueprint.ir.Field
 import com.blueprint.ir.Operation
 import com.blueprint.ir.Ownership
 import com.blueprint.ir.ProjectMeta
+import com.blueprint.ir.SourceRef
 import com.blueprint.ir.TypeRef
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -34,6 +35,7 @@ class CodeMapProjectionTest {
                     name = "Invite",
                     kind = ComponentKind.MODEL,
                     ownership = Ownership(files = listOf("app/models.py")),
+                    sourceRef = SourceRef("app/models.py", 12),
                     fields = listOf(Field("id", TypeRef("str")), Field("project", TypeRef("Project"))),
                     operations = listOf(Operation("accept"), Operation("revoke")),
                 ),
@@ -60,7 +62,9 @@ class CodeMapProjectionTest {
         assertEquals("Invite", invite.title)
         assertEquals("CODE", invite.status)
         assertEquals("model", invite.kind)
-        assertEquals("app/models.py", invite.source)
+        assertEquals("app/models.py:12", invite.source)
+        assertEquals("app/models.py", invite.sourcePath)
+        assertEquals(12, invite.sourceLine)
         assertEquals(listOf("models.project"), invite.dependencies)
         assertTrue(invite.selected)
         assertEquals(listOf("id: str", "project: Project"), invite.fields)

--- a/src/test/kotlin/com/blueprint/ui/MiniGraphPanelTest.kt
+++ b/src/test/kotlin/com/blueprint/ui/MiniGraphPanelTest.kt
@@ -1,0 +1,126 @@
+package com.blueprint.ui
+
+import java.awt.image.BufferedImage
+import java.awt.event.MouseEvent
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MiniGraphPanelTest {
+    @Test
+    fun `double clicking source-backed card opens source`() {
+        val opened = AtomicReference<MiniGraphPanel.NodeView?>()
+        val selected = AtomicReference<String?>()
+        val panel = graphPanel(
+            MiniGraphPanel.NodeView(
+                id = "models.invite",
+                title = "Invite",
+                status = "CODE",
+                wave = 1,
+                dependencies = emptyList(),
+                selected = false,
+                ready = true,
+                blocked = false,
+                detail = "Current code entity",
+                origin = MiniGraphPanel.NodeOrigin.CODE,
+                kind = "model",
+                source = "app/models.py:12",
+                sourcePath = "app/models.py",
+                sourceLine = 12,
+            ),
+        ).apply {
+            onNodeOpenSource = { opened.set(it) }
+            onNodeSelected = { selected.set(it) }
+        }
+
+        panel.dispatchClick(x = 40, y = 70, clickCount = 2)
+
+        assertEquals("models.invite", opened.get()?.id)
+        assertNull(selected.get())
+    }
+
+    @Test
+    fun `single clicking source-backed card still selects`() {
+        val opened = AtomicReference<MiniGraphPanel.NodeView?>()
+        val selected = AtomicReference<String?>()
+        val panel = graphPanel(
+            MiniGraphPanel.NodeView(
+                id = "models.invite",
+                title = "Invite",
+                status = "CODE",
+                wave = 1,
+                dependencies = emptyList(),
+                selected = false,
+                ready = true,
+                blocked = false,
+                detail = "Current code entity",
+                origin = MiniGraphPanel.NodeOrigin.CODE,
+                kind = "model",
+                source = "app/models.py:12",
+                sourcePath = "app/models.py",
+                sourceLine = 12,
+            ),
+        ).apply {
+            onNodeOpenSource = { opened.set(it) }
+            onNodeSelected = { selected.set(it) }
+        }
+
+        panel.dispatchClick(x = 40, y = 70, clickCount = 1)
+
+        assertEquals("models.invite", selected.get())
+        assertNull(opened.get())
+    }
+
+    @Test
+    fun `double clicking unmapped proposed card selects instead of opening source`() {
+        val opened = AtomicReference<MiniGraphPanel.NodeView?>()
+        val selected = AtomicReference<String?>()
+        val panel = graphPanel(
+            MiniGraphPanel.NodeView(
+                id = "InvitePolicy",
+                title = "InvitePolicy",
+                status = "UML",
+                wave = 1,
+                dependencies = emptyList(),
+                selected = false,
+                ready = true,
+                blocked = false,
+                detail = "Proposed UML entity",
+                origin = MiniGraphPanel.NodeOrigin.PROPOSED_UML,
+                kind = "UML entity",
+            ),
+        ).apply {
+            onNodeOpenSource = { opened.set(it) }
+            onNodeSelected = { selected.set(it) }
+        }
+
+        panel.dispatchClick(x = 40, y = 70, clickCount = 2)
+
+        assertEquals("InvitePolicy", selected.get())
+        assertNull(opened.get())
+    }
+
+    private fun graphPanel(node: MiniGraphPanel.NodeView): MiniGraphPanel =
+        MiniGraphPanel().apply {
+            setSize(900, 420)
+            setGraph(listOf(node))
+            paint(BufferedImage(900, 420, BufferedImage.TYPE_INT_ARGB).createGraphics())
+        }
+
+    private fun MiniGraphPanel.dispatchClick(x: Int, y: Int, clickCount: Int) {
+        dispatchEvent(
+            MouseEvent(
+                this,
+                MouseEvent.MOUSE_CLICKED,
+                System.currentTimeMillis(),
+                0,
+                x,
+                y,
+                clickCount,
+                false,
+                MouseEvent.BUTTON1,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- carry source path/line through code-map node views
- show source state honestly on cards/tooltips, including unmapped proposed UML
- open source-backed cards via double-click or the source badge in the IDE
- cover projection source refs and graph click behavior with tests

## Test
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew test --no-daemon

Closes #7