### PR TITLE
Fix #9: Group and filter the code map

### DIFF
--- a/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
+++ b/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
@@ -381,6 +381,13 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
     private val previewDiffButton = JButton("Preview Diff").apply { addActionListener { previewDiff() } }
     private val advancedMode = JBCheckBox("Advanced")
     private val filterCombo = JComboBox(NodeFilter.values())
+    private val codeMapGroupCombo = JComboBox(CodeMapProjection.GroupMode.values()).apply {
+        selectedItem = CodeMapProjection.GroupMode.PACKAGE
+    }
+    private val hideCodeMapTests = JBCheckBox("Hide tests")
+    private val hideGeneratedCodeMap = JBCheckBox("Hide generated")
+    private val hideExternalCodeMapEdges = JBCheckBox("Hide imports").apply { isSelected = true }
+    private val hideLowConfidenceCodeMapEdges = JBCheckBox("Hide weak edges")
     private var umlHasPendingEdits = false
     private var suppressUmlDocumentEvents = false
     private val activityLog = JBTextArea(6, 40).apply {
@@ -657,6 +664,15 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
             refreshList()
             logActivity("Node filter: ${filterCombo.selectedItem}")
         }
+        val refreshCodeMapLayout: () -> Unit = {
+            updateMiniGraph(project.service<DependencyGraphService>().analyze())
+            logActivity("Code map layout: ${codeMapGroupCombo.selectedItem}")
+        }
+        codeMapGroupCombo.addActionListener { refreshCodeMapLayout() }
+        hideCodeMapTests.addActionListener { refreshCodeMapLayout() }
+        hideGeneratedCodeMap.addActionListener { refreshCodeMapLayout() }
+        hideExternalCodeMapEdges.addActionListener { refreshCodeMapLayout() }
+        hideLowConfidenceCodeMapEdges.addActionListener { refreshCodeMapLayout() }
         val overview = JPanel(GridLayout(0, 1, 4, 4)).apply {
             border = BorderFactory.createTitledBorder("Overview")
             add(JLabel("Project: ${project.name}").apply { foreground = Color(0x333333) })
@@ -763,6 +779,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
                     add(JButton("Refresh UML").apply { addActionListener { generateProjectUml() } })
                     add(JButton("Generate Code Diff").apply { addActionListener { generateCodeDiffFromCurrentUml() } })
                 }, BorderLayout.EAST)
+                add(codeMapControls(), BorderLayout.SOUTH)
             }, BorderLayout.NORTH)
             add(JBScrollPane(miniGraph).apply {
                 viewport.background = BlueprintTheme.Background
@@ -799,6 +816,16 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
             }
         }
     }
+
+    private fun codeMapControls(): JPanel =
+        JPanel(FlowLayout(FlowLayout.LEFT, 6, 2)).apply {
+            add(JLabel("Group"))
+            add(codeMapGroupCombo.apply { preferredSize = Dimension(130, 32) })
+            add(hideCodeMapTests)
+            add(hideGeneratedCodeMap)
+            add(hideExternalCodeMapEdges)
+            add(hideLowConfidenceCodeMapEdges)
+        }
 
     private fun criteriaPanel(): JPanel =
         JPanel(BorderLayout()).apply {
@@ -2510,6 +2537,14 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
             ir = ir,
             selectedId = selectedCanvasId ?: selectedNodeId,
             workflowByComponentId = workflowByComponent,
+            options = CodeMapProjection.Options(
+                groupMode = codeMapGroupCombo.selectedItem as? CodeMapProjection.GroupMode
+                    ?: CodeMapProjection.GroupMode.PACKAGE,
+                hideTests = hideCodeMapTests.isSelected,
+                hideGenerated = hideGeneratedCodeMap.isSelected,
+                hideExternalEdges = hideExternalCodeMapEdges.isSelected,
+                hideLowConfidenceEdges = hideLowConfidenceCodeMapEdges.isSelected,
+            ),
         )
     }
 

--- a/src/main/kotlin/com/blueprint/ui/CodeMapProjection.kt
+++ b/src/main/kotlin/com/blueprint/ui/CodeMapProjection.kt
@@ -7,6 +7,7 @@ import com.blueprint.ir.Edge
 import com.blueprint.ir.EdgeKind
 import com.blueprint.ir.EdgeTargetKind
 import com.blueprint.ir.Field
+import com.blueprint.ir.Module
 import com.blueprint.ir.Operation
 
 /**
@@ -15,6 +16,29 @@ import com.blueprint.ir.Operation
  * optional metadata layered onto those code entities.
  */
 object CodeMapProjection {
+    enum class GroupMode {
+        DEPENDENCY,
+        PACKAGE,
+        LAYER,
+        ;
+
+        override fun toString(): String =
+            when (this) {
+                DEPENDENCY -> "Dependency"
+                PACKAGE -> "Package"
+                LAYER -> "Layer"
+            }
+    }
+
+    data class Options(
+        val groupMode: GroupMode = GroupMode.DEPENDENCY,
+        val hideTests: Boolean = false,
+        val hideGenerated: Boolean = false,
+        val hideExternalEdges: Boolean = false,
+        val hideLowConfidenceEdges: Boolean = false,
+        val lowConfidenceThreshold: Double = 0.7,
+    )
+
     data class WorkflowBadge(
         val status: String,
         val ready: Boolean,
@@ -26,13 +50,22 @@ object CodeMapProjection {
         ir: ArchitectureIR,
         selectedId: String?,
         workflowByComponentId: Map<String, WorkflowBadge> = emptyMap(),
+        options: Options = Options(),
     ): List<MiniGraphPanel.NodeView> {
         if (ir.components.isEmpty()) return emptyList()
 
-        val componentsById = ir.components.associateBy { it.id }
+        val modulesByComponentId = ir.modules
+            .flatMap { module -> module.componentIds.map { componentId -> componentId to module } }
+            .toMap()
+        val visibleComponents = ir.components
+            .filterNot { options.hideTests && it.kind == ComponentKind.TEST }
+            .filterNot { options.hideGenerated && it.isGeneratedBlueprintCode() }
+        val componentsById = visibleComponents.associateBy { it.id }
         val componentEdges = ir.edges
             .filter { it.toKind == EdgeTargetKind.COMPONENT }
             .filter { it.from in componentsById && it.to in componentsById }
+            .filterNot { options.hideExternalEdges && it.isExternalOrLibraryEdge() }
+            .filterNot { options.hideLowConfidenceEdges && it.confidence < options.lowConfidenceThreshold }
         val dependenciesById = componentEdges
             .groupBy({ it.to }, { it.from })
             .mapValues { (_, deps) -> deps.distinct() }
@@ -52,12 +85,23 @@ object CodeMapProjection {
             waveMemo[id] = wave
             return wave
         }
+        val groupInfoById = groupInfoByComponent(
+            components = visibleComponents,
+            modulesByComponentId = modulesByComponentId,
+            waveOf = { id -> waveOf(id) },
+            options = options,
+        )
 
-        return ir.components
-            .sortedWith(compareBy<Component>({ waveOf(it.id) }, { it.ownership.files.firstOrNull() ?: "" }, { it.name }))
+        return visibleComponents
+            .sortedWith(compareBy<Component>(
+                { groupInfoById.getValue(it.id).order },
+                { it.ownership.files.firstOrNull() ?: "" },
+                { it.name },
+            ))
             .map { component ->
                 val workflow = workflowByComponentId[component.id]
                 val sourceTarget = component.sourceTarget()
+                val groupInfo = groupInfoById.getValue(component.id)
                 MiniGraphPanel.NodeView(
                     id = component.id,
                     title = component.name,
@@ -82,6 +126,8 @@ object CodeMapProjection {
                         incoming = incomingEdgesById[component.id].orEmpty(),
                         outgoing = outgoingEdgesById[component.id].orEmpty(),
                     ),
+                    groupTitle = groupInfo.title,
+                    groupOrder = groupInfo.order,
                 )
             }
     }
@@ -159,6 +205,62 @@ object CodeMapProjection {
         return listOf(counts, labels).filter { it.isNotBlank() }.joinToString(" · ")
     }
 
+    private fun groupInfoByComponent(
+        components: List<Component>,
+        modulesByComponentId: Map<String, Module>,
+        waveOf: (String) -> Int,
+        options: Options,
+    ): Map<String, GroupInfo> {
+        val labelsById = components.associate { component ->
+            component.id to when (options.groupMode) {
+                GroupMode.DEPENDENCY -> "Wave ${waveOf(component.id)}"
+                GroupMode.PACKAGE -> packageLabel(component, modulesByComponentId[component.id])
+                GroupMode.LAYER -> layerLabel(component)
+            }
+        }
+        val orderByLabel = when (options.groupMode) {
+            GroupMode.DEPENDENCY -> labelsById.values.distinct().associateWith { label ->
+                label.substringAfter("Wave ", "1").toIntOrNull() ?: 1
+            }
+            GroupMode.LAYER -> layerOrderByLabel
+            GroupMode.PACKAGE -> labelsById.values.distinct().sorted().mapIndexed { index, label -> label to index + 1 }.toMap()
+        }
+        return labelsById.mapValues { (_, label) ->
+            GroupInfo(label, orderByLabel[label] ?: 99)
+        }
+    }
+
+    private fun packageLabel(component: Component, module: Module?): String {
+        val raw = module?.name?.takeIf { it.isNotBlank() }
+            ?: module?.path?.trimEnd('/')
+            ?: component.sourceTarget().path.substringBeforeLast("/", "")
+        val label = raw.ifBlank { "(root)" }
+        return "Package: $label"
+    }
+
+    private fun layerLabel(component: Component): String =
+        when {
+            component.tags.contains("route") -> "Layer: API"
+            component.kind == ComponentKind.CLI -> "Layer: API"
+            component.kind == ComponentKind.SERVICE -> "Layer: Service"
+            component.kind == ComponentKind.MODEL -> "Layer: Model"
+            component.kind == ComponentKind.ADAPTER -> "Layer: Adapter"
+            component.kind == ComponentKind.PORT -> "Layer: Port"
+            component.kind == ComponentKind.TEST -> "Layer: Test"
+            else -> "Layer: Other"
+        }
+
+    private fun Component.isGeneratedBlueprintCode(): Boolean =
+        ownership.files.any { it.startsWith("blueprint_demo/") } ||
+            sourceRef?.path?.startsWith("blueprint_demo/") == true ||
+            tags.contains("scaffold") ||
+            id.startsWith("imported.")
+
+    private fun Edge.isExternalOrLibraryEdge(): Boolean =
+        label.equals("import", ignoreCase = true) ||
+            evidence.startsWith("imported symbol:", ignoreCase = true) ||
+            confidence <= 0.65
+
     private fun ComponentKind.codeMapLabel(): String =
         name.lowercase().replace('_', ' ')
 
@@ -169,5 +271,20 @@ object CodeMapProjection {
         val path: String,
         val line: Int?,
         val label: String,
+    )
+
+    private data class GroupInfo(
+        val title: String,
+        val order: Int,
+    )
+
+    private val layerOrderByLabel = mapOf(
+        "Layer: API" to 1,
+        "Layer: Service" to 2,
+        "Layer: Adapter" to 3,
+        "Layer: Port" to 4,
+        "Layer: Model" to 5,
+        "Layer: Test" to 6,
+        "Layer: Other" to 7,
     )
 }

--- a/src/main/kotlin/com/blueprint/ui/MiniGraphPanel.kt
+++ b/src/main/kotlin/com/blueprint/ui/MiniGraphPanel.kt
@@ -67,6 +67,8 @@ class MiniGraphPanel : JPanel() {
         val methods: List<String> = emptyList(),
         val methodOverflowCount: Int = 0,
         val relationshipHint: String = "",
+        val groupTitle: String = "",
+        val groupOrder: Int = 0,
     )
 
     private var nodes: List<NodeView> = emptyList()
@@ -156,7 +158,7 @@ class MiniGraphPanel : JPanel() {
             return
         }
 
-        val waves = nodes.groupBy { it.wave }.toSortedMap()
+        val layoutGroups = layoutGroups()
         val richCards = nodes.any { it.hasRichFacts() }
         val cardW = if (richCards) 292f else 230f
         val cardH = if (richCards) 132f else 76f
@@ -167,12 +169,12 @@ class MiniGraphPanel : JPanel() {
         val localCards = mutableMapOf<String, RoundRectangle2D.Float>()
         val localSourceBadges = mutableMapOf<String, RoundRectangle2D.Float>()
 
-        waves.entries.forEachIndexed { waveIndex, (wave, waveNodes) ->
-            val x = startX + waveIndex * (cardW + gapX)
+        layoutGroups.forEachIndexed { groupIndex, group ->
+            val x = startX + groupIndex * (cardW + gapX)
             g.color = Theme.TextStrong
             g.font = font.deriveFont(Font.BOLD, 12f)
-            g.drawString("Wave $wave", x.toInt(), 28)
-            waveNodes.forEachIndexed { row, node ->
+            g.drawString(group.title.ellipsizeToWidth(g, cardW.toInt()), x.toInt(), 28)
+            group.nodes.forEachIndexed { row, node ->
                 val y = startY + row * (cardH + gapY)
                 localCards[node.id] = RoundRectangle2D.Float(x, y, cardW, cardH, 10f, 10f)
             }
@@ -285,9 +287,9 @@ class MiniGraphPanel : JPanel() {
         val gapY = 24
         val startX = 24
         val startY = 46
-        val waves = nodes.groupBy { it.wave }.toSortedMap()
-        val columns = waves.size.coerceAtLeast(1)
-        val maxRows = (waves.values.maxOfOrNull { it.size } ?: 1).coerceAtLeast(1)
+        val layoutGroups = layoutGroups()
+        val columns = layoutGroups.size.coerceAtLeast(1)
+        val maxRows = (layoutGroups.maxOfOrNull { it.nodes.size } ?: 1).coerceAtLeast(1)
         val contentWidth = startX + columns * cardW + (columns - 1) * gapX + 24
         val contentHeight = startY + maxRows * cardH + (maxRows - 1) * gapY + 28
         preferredSize = Dimension(
@@ -295,6 +297,24 @@ class MiniGraphPanel : JPanel() {
             contentHeight.toInt().coerceAtLeast(minimumSize.height),
         )
     }
+
+    private fun layoutGroups(): List<LayoutGroup> =
+        nodes
+            .groupBy { it.displayGroupTitle() }
+            .map { (title, groupNodes) ->
+                LayoutGroup(
+                    title = title,
+                    order = groupNodes.minOf { it.displayGroupOrder() },
+                    nodes = groupNodes.sortedWith(compareBy<NodeView>({ it.wave }, { it.sourcePath }, { it.title })),
+                )
+            }
+            .sortedWith(compareBy<LayoutGroup>({ it.order }, { it.title }))
+
+    private data class LayoutGroup(
+        val title: String,
+        val order: Int,
+        val nodes: List<NodeView>,
+    )
 
     private fun nodeAt(point: Point): NodeView? {
         val id = cards.entries.firstOrNull { (_, card) -> card.contains(point) }?.key ?: return null
@@ -441,6 +461,12 @@ class MiniGraphPanel : JPanel() {
 
     private fun NodeView.hasSourceTarget(): Boolean =
         sourcePath.isNotBlank()
+
+    private fun NodeView.displayGroupTitle(): String =
+        groupTitle.ifBlank { "Wave $wave" }
+
+    private fun NodeView.displayGroupOrder(): Int =
+        groupOrder.takeIf { it != 0 } ?: wave
 
     private fun NodeView.sourceDescription(): String =
         when {

--- a/src/test/kotlin/com/blueprint/ui/CodeMapProjectionTest.kt
+++ b/src/test/kotlin/com/blueprint/ui/CodeMapProjectionTest.kt
@@ -7,6 +7,7 @@ import com.blueprint.ir.Edge
 import com.blueprint.ir.EdgeKind
 import com.blueprint.ir.EdgeTargetKind
 import com.blueprint.ir.Field
+import com.blueprint.ir.Module
 import com.blueprint.ir.Operation
 import com.blueprint.ir.Ownership
 import com.blueprint.ir.ProjectMeta
@@ -137,5 +138,164 @@ class CodeMapProjectionTest {
         assertEquals(1, bank.fieldOverflowCount)
         assertEquals(listOf("deposit()", "withdraw()"), bank.methods)
         assertEquals(1, bank.methodOverflowCount)
+    }
+
+    @Test
+    fun `projection can group code entities by package modules`() {
+        val ir = ArchitectureIR(
+            modules = listOf(
+                Module("app.models", "app.models", "app/models/", componentIds = listOf("app.models.invite")),
+                Module("app.services", "app.services", "app/services/", componentIds = listOf("app.services.invite")),
+            ),
+            components = listOf(
+                Component(
+                    id = "app.models.invite",
+                    name = "Invite",
+                    kind = ComponentKind.MODEL,
+                    ownership = Ownership(files = listOf("app/models/invite.py")),
+                ),
+                Component(
+                    id = "app.services.invite",
+                    name = "InviteService",
+                    kind = ComponentKind.SERVICE,
+                    ownership = Ownership(files = listOf("app/services/invite.py")),
+                ),
+            ),
+        )
+
+        val views = CodeMapProjection.fromIr(
+            ir = ir,
+            selectedId = null,
+            options = CodeMapProjection.Options(groupMode = CodeMapProjection.GroupMode.PACKAGE),
+        )
+
+        assertEquals("Package: app.models", views.single { it.id == "app.models.invite" }.groupTitle)
+        assertEquals("Package: app.services", views.single { it.id == "app.services.invite" }.groupTitle)
+        assertTrue(views.map { it.groupOrder }.toSet().size == 2)
+    }
+
+    @Test
+    fun `projection can group code entities by architectural layer`() {
+        val ir = ArchitectureIR(
+            components = listOf(
+                Component(
+                    id = "app.routes.create_invite",
+                    name = "create_invite",
+                    kind = ComponentKind.SERVICE,
+                    tags = setOf("route"),
+                    ownership = Ownership(files = listOf("app/routes.py")),
+                ),
+                Component(
+                    id = "app.service.invite",
+                    name = "InviteService",
+                    kind = ComponentKind.SERVICE,
+                    ownership = Ownership(files = listOf("app/service.py")),
+                ),
+                Component(
+                    id = "app.models.invite",
+                    name = "Invite",
+                    kind = ComponentKind.MODEL,
+                    ownership = Ownership(files = listOf("app/models.py")),
+                ),
+                Component(
+                    id = "tests.test_invite",
+                    name = "test_invite",
+                    kind = ComponentKind.TEST,
+                    ownership = Ownership(files = listOf("tests/test_invite.py")),
+                ),
+            ),
+        )
+
+        val views = CodeMapProjection.fromIr(
+            ir = ir,
+            selectedId = null,
+            options = CodeMapProjection.Options(groupMode = CodeMapProjection.GroupMode.LAYER),
+        )
+
+        assertEquals("Layer: API", views.single { it.id == "app.routes.create_invite" }.groupTitle)
+        assertEquals("Layer: Service", views.single { it.id == "app.service.invite" }.groupTitle)
+        assertEquals("Layer: Model", views.single { it.id == "app.models.invite" }.groupTitle)
+        assertEquals("Layer: Test", views.single { it.id == "tests.test_invite" }.groupTitle)
+        assertTrue(
+            views.single { it.id == "app.routes.create_invite" }.groupOrder <
+                views.single { it.id == "app.models.invite" }.groupOrder,
+        )
+    }
+
+    @Test
+    fun `projection filters tests generated nodes and noisy edges`() {
+        val ir = ArchitectureIR(
+            components = listOf(
+                Component(
+                    id = "app.models.invite",
+                    name = "Invite",
+                    kind = ComponentKind.MODEL,
+                    ownership = Ownership(files = listOf("app/models.py")),
+                ),
+                Component(
+                    id = "app.service.invite",
+                    name = "InviteService",
+                    kind = ComponentKind.SERVICE,
+                    ownership = Ownership(files = listOf("app/service.py")),
+                ),
+                Component(
+                    id = "tests.test_invite",
+                    name = "test_invite",
+                    kind = ComponentKind.TEST,
+                    ownership = Ownership(files = listOf("tests/test_invite.py")),
+                ),
+                Component(
+                    id = "imported.invite.models.invitepolicy",
+                    name = "InvitePolicy",
+                    kind = ComponentKind.MODEL,
+                    ownership = Ownership(files = listOf("blueprint_demo/imported_invite/models.py")),
+                ),
+            ),
+            edges = listOf(
+                Edge(
+                    from = "app.service.invite",
+                    to = "app.models.invite",
+                    toKind = EdgeTargetKind.COMPONENT,
+                    kind = EdgeKind.REFERENCES,
+                    label = "uses",
+                    evidence = "typed parameter",
+                    confidence = 0.95,
+                ),
+                Edge(
+                    from = "tests.test_invite",
+                    to = "app.service.invite",
+                    toKind = EdgeTargetKind.COMPONENT,
+                    kind = EdgeKind.CALLS,
+                    label = "tests",
+                    evidence = "call expression: InviteService",
+                    confidence = 0.8,
+                ),
+                Edge(
+                    from = "app.models.invite",
+                    to = "app.service.invite",
+                    toKind = EdgeTargetKind.COMPONENT,
+                    kind = EdgeKind.REFERENCES,
+                    label = "import",
+                    evidence = "imported symbol: InviteService",
+                    confidence = 0.65,
+                ),
+            ),
+        )
+
+        val views = CodeMapProjection.fromIr(
+            ir = ir,
+            selectedId = null,
+            options = CodeMapProjection.Options(
+                groupMode = CodeMapProjection.GroupMode.PACKAGE,
+                hideTests = true,
+                hideGenerated = true,
+                hideExternalEdges = true,
+                hideLowConfidenceEdges = true,
+            ),
+        )
+
+        assertEquals(setOf("app.models.invite", "app.service.invite"), views.map { it.id }.toSet())
+        assertEquals(listOf("app.service.invite"), views.single { it.id == "app.models.invite" }.dependencies)
+        assertTrue(views.single { it.id == "app.service.invite" }.dependencies.isEmpty())
     }
 }


### PR DESCRIPTION
## Summary
- add code-map grouping modes for dependency, package/module, and architectural layer
- add noise filters for tests, generated Blueprint code, import/external-style edges, and low-confidence edges
- teach the mini graph to render custom group columns instead of only dependency waves
- cover package grouping, layer grouping, and filters in projection tests

## Test
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew test --no-daemon

Closes #9