### PR TITLE
Generate AST-backed UML model patches

### DIFF
--- a/src/main/kotlin/com/blueprint/service/NodeExecutionService.kt
+++ b/src/main/kotlin/com/blueprint/service/NodeExecutionService.kt
@@ -66,28 +66,32 @@ class NodeExecutionService(private val project: Project) {
     private fun executeAggregateModels(node: BlueprintNode, plan: PlanArtifact?): ExecutionArtifact {
         val path = node.fileScope.paths.firstOrNull() ?: "blueprint_demo/imported_models/models.py"
         val modelOutputs = freshestModelOutputs(node).ifEmpty { node.outputs }
-        val content = renderModelsModule(modelOutputs)
+        val existingContent = project.service<ApplyChangesService>().readCurrentContent(path)
+        val action = if (existingContent.isBlank()) "create" else "update"
+        val rendered = PythonModelModuleRenderer.renderWithReport(modelOutputs, existingContent)
+        val content = rendered.content
+        val changeSummary = rendered.changes.ifEmpty { listOf("no model changes") }.joinToString("; ")
         return ExecutionArtifact(
             status = "SUCCESS",
-            summary = "Generated a deterministic Python dataclass models module from the current UML.",
+            summary = "Generated deterministic Python dataclass model changes from the current UML: $changeSummary.",
             assumptions = listOf("UML schema fields are the source of truth for the shared models file."),
             touchedFiles = listOf(TouchedFile(
                 path = path,
-                action = if (project.service<ApplyChangesService>().readCurrentContent(path).isBlank()) "create" else "update",
+                action = action,
                 reason = "Synchronize shared model classes with UML.",
             )),
             plan = plan?.implementationSteps?.map { it.title.ifBlank { it.details } }?.filter { it.isNotBlank() }
-                ?: listOf("Render all UML model classes into the shared models module."),
+                ?: listOf("Merge UML model fields into the shared models module."),
             patches = listOf(Patch(
                 path = path,
-                action = if (project.service<ApplyChangesService>().readCurrentContent(path).isBlank()) "create" else "update",
+                action = action,
                 content = content,
             )),
             acceptanceCheck = node.acceptanceCriteria.map {
                 AcceptanceCheckItem(
                     criterion = it.id.ifBlank { it.description },
                     result = "PASS",
-                    notes = "Deterministic model generator emitted all declared UML schema fields.",
+                    notes = "Deterministic model generator emitted all declared UML schema fields and required imports.",
                 )
             },
             validation = ExecutionValidation(
@@ -115,66 +119,6 @@ class NodeExecutionService(private val project: Project) {
                 )
             }
             .sortedBy { it.name }
-    }
-
-    private fun renderModelsModule(outputs: List<NodeContract>): String {
-        val classes = orderedModelOutputs(outputs)
-        val needsDatetime = classes.any { (_, fields) -> fields.any { it.second == "datetime" } }
-        return buildString {
-            appendLine("from dataclasses import dataclass")
-            if (needsDatetime) appendLine("from datetime import datetime")
-            appendLine()
-            classes.forEachIndexed { index, (name, fields) ->
-                if (index > 0) appendLine()
-                appendLine("@dataclass")
-                appendLine("class $name:")
-                if (fields.isEmpty()) {
-                    appendLine("    pass")
-                } else {
-                    fields.forEach { (field, type) -> appendLine("    $field: $type") }
-                }
-            }
-        }.trimEnd() + "\n"
-    }
-
-    private fun orderedModelOutputs(outputs: List<NodeContract>): List<Pair<String, List<Pair<String, String>>>> {
-        val parsed = outputs
-            .filter { it.name.matches(Regex("""[A-Za-z_][A-Za-z0-9_]*""")) }
-            .associate { output ->
-                output.name to output.schema.lines().mapNotNull(::parseFieldLine)
-            }
-        val names = parsed.keys
-        val visited = mutableSetOf<String>()
-        val visiting = mutableSetOf<String>()
-        val ordered = mutableListOf<String>()
-
-        fun visit(name: String) {
-            if (name in visited || name in visiting) return
-            visiting += name
-            parsed[name].orEmpty()
-                .map { (_, type) -> type.substringBefore("[").substringBefore("?").trim() }
-                .filter { it in names }
-                .sorted()
-                .forEach(::visit)
-            visiting -= name
-            visited += name
-            ordered += name
-        }
-
-        names.sorted().forEach(::visit)
-        return ordered.map { it to parsed.getValue(it) }
-    }
-
-    private fun parseFieldLine(line: String): Pair<String, String>? {
-        val cleaned = line
-            .replace("&lt;", "<")
-            .replace("&gt;", ">")
-            .trim()
-        val name = cleaned.substringBefore(":", "").trim()
-        val type = cleaned.substringAfter(":", "").trim()
-        if (!name.matches(Regex("""[A-Za-z_][A-Za-z0-9_]*"""))) return null
-        if (type.isBlank()) return null
-        return name to type
     }
 
     private fun enforceScope(node: BlueprintNode, exec: ExecutionArtifact): ExecutionArtifact {

--- a/src/main/kotlin/com/blueprint/service/PythonModelModuleRenderer.kt
+++ b/src/main/kotlin/com/blueprint/service/PythonModelModuleRenderer.kt
@@ -1,0 +1,408 @@
+package com.blueprint.service
+
+import com.blueprint.model.NodeContract
+import com.google.gson.Gson
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+/**
+ * Renders the shared UML model module with small, AST-backed edits.
+ *
+ * It is intentionally conservative rather than a general Python formatter:
+ * Python's ast module identifies existing class ranges and annotated fields.
+ * Top-level imports/classes/functions outside the UML-owned dataclasses are
+ * preserved, existing class methods stay in place, and generated fields for
+ * the UML model classes are the only class body lines rewritten.
+ */
+object PythonModelModuleRenderer {
+    private val gson = Gson()
+
+    fun render(outputs: List<NodeContract>, existingContent: String = ""): String {
+        return renderWithReport(outputs, existingContent).content
+    }
+
+    fun renderWithReport(outputs: List<NodeContract>, existingContent: String = ""): RenderResult {
+        val classes = orderedModelOutputs(outputs)
+        val imports = requiredImports(classes)
+        val body = if (existingContent.isBlank()) {
+            renderFreshModule(classes)
+        } else {
+            mergeIntoExisting(existingContent, classes)
+        }
+        val content = ensureImports(body, imports).trimEnd() + "\n"
+        return RenderResult(
+            content = content,
+            changes = describeChanges(existingContent, content),
+        )
+    }
+
+    fun describeChanges(existingContent: String, proposedContent: String): List<String> {
+        val existingClasses = modelSpecsInContent(existingContent)
+        val proposedClasses = modelSpecsInContent(proposedContent)
+        val changes = mutableListOf<String>()
+
+        proposedClasses.values.sortedBy { it.name }.forEach { proposed ->
+            val existing = existingClasses[proposed.name]
+            if (existing == null) {
+                changes += "add class ${proposed.name}"
+                proposed.fields.forEach { field -> changes += "add field ${proposed.name}.${field.name}" }
+                return@forEach
+            }
+
+            val existingFields = existing.fields.associateBy { it.name }
+            val proposedFields = proposed.fields.associateBy { it.name }
+            proposed.fields.forEach { field ->
+                val old = existingFields[field.name]
+                when {
+                    old == null -> changes += "add field ${proposed.name}.${field.name}"
+                    old.type != field.type -> changes += "update field ${proposed.name}.${field.name}: ${old.type} -> ${field.type}"
+                }
+            }
+            existing.fields
+                .filterNot { it.name in proposedFields }
+                .forEach { field -> changes += "remove field ${proposed.name}.${field.name}" }
+        }
+
+        val existingLines = existingContent.replace("\r\n", "\n").replace("\r", "\n").lines()
+        val proposedImports = requiredImports(proposedClasses.values.toList())
+        proposedImports
+            .filterNot { wanted -> existingLines.any { it.trim() == wanted } }
+            .forEach { changes += "add import $it" }
+
+        return changes.distinct()
+    }
+
+    private fun renderFreshModule(classes: List<ModelSpec>): String =
+        buildString {
+            classes.forEachIndexed { index, spec ->
+                if (index > 0) appendLine()
+                append(renderClass(spec, preservedBody = emptyList()))
+            }
+        }.trimEnd()
+
+    private fun mergeIntoExisting(existingContent: String, classes: List<ModelSpec>): String {
+        val normalized = existingContent.replace("\r\n", "\n").replace("\r", "\n")
+        val lines = normalized.lines().let { if (it.lastOrNull() == "") it.dropLast(1) else it }
+        val astBlocks = astClassBlocks(normalized).associateBy { it.start }
+        val byName = classes.associateBy { it.name }
+        val handled = mutableSetOf<String>()
+        val out = mutableListOf<String>()
+        var index = 0
+
+        while (index < lines.size) {
+            val block = astBlocks[index] ?: classBlockAt(lines, index)
+            if (block == null) {
+                out += lines[index]
+                index += 1
+                continue
+            }
+            val spec = byName[block.name]
+            if (spec == null) {
+                out += lines.subList(block.start, block.endExclusive)
+            } else {
+                handled += spec.name
+                out += renderClass(spec, preservedBody = preservedClassBody(lines.subList(block.classLine + 1, block.endExclusive))).lines()
+            }
+            index = block.endExclusive
+        }
+
+        classes.filterNot { it.name in handled }.forEach { spec ->
+            trimTrailingBlankLines(out)
+            if (out.isNotEmpty()) out += ""
+            out += renderClass(spec, preservedBody = emptyList()).lines()
+        }
+
+        return out.joinToString("\n")
+    }
+
+    private fun renderClass(spec: ModelSpec, preservedBody: List<String>): String =
+        buildString {
+            appendLine("@dataclass")
+            appendLine("class ${spec.name}:")
+            if (spec.fields.isEmpty() && preservedBody.isEmpty()) {
+                appendLine("    pass")
+                return@buildString
+            }
+            spec.fields.forEach { field -> appendLine("    ${field.name}: ${field.type}") }
+            if (preservedBody.isNotEmpty()) {
+                if (spec.fields.isNotEmpty()) appendLine()
+                preservedBody.forEach { appendLine(it) }
+            }
+        }.trimEnd()
+
+    private fun preservedClassBody(bodyLines: List<String>): List<String> {
+        val kept = bodyLines.filterNot { line ->
+            val trimmed = line.trim()
+            trimmed == "pass" || TOP_LEVEL_FIELD.matches(line)
+        }.toMutableList()
+        trimLeadingBlankLines(kept)
+        trimTrailingBlankLines(kept)
+        return kept
+    }
+
+    private fun classBlockAt(lines: List<String>, index: Int): ClassBlock? {
+        var classLine = index
+        var classMatch = CLASS_HEADER.find(lines[classLine])
+        if (classMatch == null && isTopLevelDecorator(lines[index])) {
+            classLine = index
+            while (classLine < lines.size && isTopLevelDecorator(lines[classLine])) classLine += 1
+            classMatch = lines.getOrNull(classLine)?.let(CLASS_HEADER::find)
+        }
+        classMatch ?: return null
+
+        var start = classLine
+        while (start > 0 && isTopLevelDecorator(lines[start - 1])) {
+            start -= 1
+        }
+        var end = classLine + 1
+        while (end < lines.size) {
+            val line = lines[end]
+            if (line.isNotBlank() && !line.startsWith(" ") && !line.startsWith("\t")) {
+                if (!line.trimStart().startsWith("@")) break
+                val next = lines.getOrNull(end + 1)
+                if (next != null && CLASS_HEADER.find(next) != null) break
+            }
+            end += 1
+        }
+        return ClassBlock(
+            name = classMatch.groupValues[1],
+            start = start,
+            classLine = classLine,
+            endExclusive = end,
+        )
+    }
+
+    private fun isTopLevelDecorator(line: String): Boolean =
+        line.startsWith("@")
+
+    private fun ensureImports(content: String, imports: List<String>): String {
+        val lines = content.lines().toMutableList()
+        val missing = imports.filterNot { wanted -> lines.any { it.trim() == wanted } }
+        if (missing.isEmpty()) return content
+        val insertAt = importInsertionIndex(lines)
+        lines.addAll(insertAt, missing + "")
+        return lines.joinToString("\n")
+    }
+
+    private fun importInsertionIndex(lines: List<String>): Int {
+        var index = 0
+        if (lines.firstOrNull()?.startsWith("#!") == true) index += 1
+        if (lines.getOrNull(index)?.startsWith("\"\"\"") == true || lines.getOrNull(index)?.startsWith("'''") == true) {
+            val quote = lines[index].take(3)
+            index += 1
+            while (index < lines.size && !lines[index].contains(quote)) index += 1
+            if (index < lines.size) index += 1
+        }
+        while (index < lines.size && lines[index].startsWith("from __future__ import ")) index += 1
+        return index
+    }
+
+    private fun requiredImports(classes: List<ModelSpec>): List<String> {
+        val typeNames = classes.flatMap { spec -> spec.fields.flatMap { typeIdentifiers(it.type) } }.toSet()
+        val imports = mutableListOf("from dataclasses import dataclass")
+        val datetimeNames = listOf("date", "datetime", "time", "timedelta").filter { it in typeNames }
+        if (datetimeNames.isNotEmpty()) imports += "from datetime import ${datetimeNames.sorted().joinToString(", ")}"
+        if ("Decimal" in typeNames) imports += "from decimal import Decimal"
+        if ("UUID" in typeNames) imports += "from uuid import UUID"
+        val typingNames = listOf("Any", "Dict", "List", "Optional", "Set", "Tuple", "Union").filter { it in typeNames }
+        if (typingNames.isNotEmpty()) imports += "from typing import ${typingNames.sorted().joinToString(", ")}"
+        return imports
+    }
+
+    private fun typeIdentifiers(raw: String): List<String> =
+        Regex("""[A-Za-z_][A-Za-z0-9_]*""")
+            .findAll(raw.removeSurrounding("\"").removeSurrounding("'"))
+            .map { it.value }
+            .filterNot { it in builtinTypeNames }
+            .toList()
+
+    private fun orderedModelOutputs(outputs: List<NodeContract>): List<ModelSpec> {
+        val parsed = outputs
+            .filter { it.name.matches(IDENTIFIER) }
+            .associate { output ->
+                output.name to ModelSpec(
+                    name = output.name,
+                    fields = output.schema.lines().mapNotNull(::parseFieldLine),
+                )
+            }
+        val names = parsed.keys
+        val visited = mutableSetOf<String>()
+        val visiting = mutableSetOf<String>()
+        val ordered = mutableListOf<String>()
+
+        fun visit(name: String) {
+            if (name in visited || name in visiting) return
+            visiting += name
+            parsed[name]?.fields.orEmpty()
+                .flatMap { typeIdentifiers(it.type) }
+                .filter { it in names }
+                .sorted()
+                .forEach(::visit)
+            visiting -= name
+            visited += name
+            ordered += name
+        }
+
+        names.sorted().forEach(::visit)
+        return ordered.map { parsed.getValue(it) }
+    }
+
+    private fun modelSpecsInContent(content: String): Map<String, ModelSpec> {
+        val normalized = content.replace("\r\n", "\n").replace("\r", "\n")
+        val lines = normalized.lines().let { if (it.lastOrNull() == "") it.dropLast(1) else it }
+        val astBlocks = astClassBlocks(normalized).associateBy { it.start }
+        val specs = mutableMapOf<String, ModelSpec>()
+        var index = 0
+        while (index < lines.size) {
+            val block = astBlocks[index] ?: classBlockAt(lines, index)
+            if (block == null) {
+                index += 1
+                continue
+            }
+            specs[block.name] = ModelSpec(
+                name = block.name,
+                fields = block.fields ?: lines.subList(block.classLine + 1, block.endExclusive).mapNotNull(::parseFieldLine),
+            )
+            index = block.endExclusive
+        }
+        return specs
+    }
+
+    private fun astClassBlocks(content: String): List<ClassBlock> {
+        if (content.isBlank()) return emptyList()
+        val python = findPythonExecutable() ?: return emptyList()
+        return try {
+            val process = ProcessBuilder(python, "-c", AST_CLASS_SCRIPT)
+                .redirectErrorStream(true)
+                .start()
+            OutputStreamWriter(process.outputStream, StandardCharsets.UTF_8).use { writer ->
+                gson.toJson(AstClassRequest(content), writer)
+            }
+            val finished = process.waitFor(5, TimeUnit.SECONDS)
+            if (!finished) {
+                process.destroyForcibly()
+                return emptyList()
+            }
+            if (process.exitValue() != 0) return emptyList()
+            val stdout = process.inputStream.readBytes().toString(StandardCharsets.UTF_8)
+            val output = gson.fromJson(stdout, AstClassOutput::class.java)
+            output.classes
+                .filter { it.name.matches(IDENTIFIER) && it.classLine > 0 && it.endExclusive >= it.classLine }
+                .map { cls ->
+                    ClassBlock(
+                        name = cls.name,
+                        start = (cls.start - 1).coerceAtLeast(0),
+                        classLine = (cls.classLine - 1).coerceAtLeast(0),
+                        endExclusive = cls.endExclusive,
+                        fields = cls.fields
+                            .filter { it.name.matches(IDENTIFIER) && it.type.isNotBlank() }
+                            .map { ModelField(it.name, it.type) },
+                    )
+                }
+        } catch (_: Throwable) {
+            emptyList()
+        }
+    }
+
+    private fun findPythonExecutable(): String? {
+        val candidates = listOf("python3", "python")
+        return candidates.firstOrNull { exe ->
+            try {
+                val process = ProcessBuilder(exe, "--version").redirectErrorStream(true).start()
+                process.waitFor(3, TimeUnit.SECONDS) && process.exitValue() == 0
+            } catch (_: Throwable) {
+                false
+            }
+        }
+    }
+
+    private fun parseFieldLine(line: String): ModelField? {
+        val cleaned = line
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .trim()
+        val name = cleaned.substringBefore(":", "").trim()
+        val type = cleaned.substringAfter(":", "").trim()
+        if (!name.matches(IDENTIFIER)) return null
+        if (type.isBlank()) return null
+        return ModelField(name, type)
+    }
+
+    private fun trimLeadingBlankLines(lines: MutableList<String>) {
+        while (lines.firstOrNull()?.isBlank() == true) lines.removeAt(0)
+    }
+
+    private fun trimTrailingBlankLines(lines: MutableList<String>) {
+        while (lines.lastOrNull()?.isBlank() == true) lines.removeAt(lines.lastIndex)
+    }
+
+    data class ModelSpec(val name: String, val fields: List<ModelField>)
+    data class ModelField(val name: String, val type: String)
+    data class RenderResult(val content: String, val changes: List<String>)
+
+    private data class ClassBlock(
+        val name: String,
+        val start: Int,
+        val classLine: Int,
+        val endExclusive: Int,
+        val fields: List<ModelField>? = null,
+    )
+
+    private data class AstClassRequest(val source: String)
+    private data class AstClassOutput(val classes: List<AstClass> = emptyList())
+    private data class AstClass(
+        val name: String = "",
+        val start: Int = 1,
+        val classLine: Int = 1,
+        val endExclusive: Int = 1,
+        val fields: List<AstField> = emptyList(),
+    )
+    private data class AstField(val name: String = "", val type: String = "")
+
+    private val IDENTIFIER = Regex("""[A-Za-z_][A-Za-z0-9_]*""")
+    private val CLASS_HEADER = Regex("""^class\s+([A-Za-z_][A-Za-z0-9_]*)\b.*:\s*$""")
+    private val TOP_LEVEL_FIELD = Regex("""^    [A-Za-z_][A-Za-z0-9_]*\s*:\s*[^#=]+(?:=.*)?$""")
+    private val builtinTypeNames = setOf(
+        "str", "int", "float", "bool", "bytes", "list", "dict", "set", "tuple", "None", "True", "False",
+    )
+
+    private const val AST_CLASS_SCRIPT = """
+import ast
+import json
+import sys
+
+req = json.load(sys.stdin)
+source = req.get("source", "")
+
+def unparse(node, default=""):
+    if node is None:
+        return default
+    try:
+        return ast.unparse(node).strip()
+    except Exception:
+        return default
+
+module = ast.parse(source)
+classes = []
+for node in module.body:
+    if not isinstance(node, ast.ClassDef):
+        continue
+    start = getattr(node, "lineno", 1)
+    for decorator in getattr(node, "decorator_list", []):
+        start = min(start, getattr(decorator, "lineno", start))
+    fields = []
+    for item in node.body:
+        if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+            fields.append({"name": item.target.id, "type": unparse(item.annotation, "Any")})
+    classes.append({
+        "name": node.name,
+        "start": start,
+        "classLine": getattr(node, "lineno", start),
+        "endExclusive": getattr(node, "end_lineno", getattr(node, "lineno", start)),
+        "fields": fields,
+    })
+
+print(json.dumps({"classes": classes}))
+"""
+}

--- a/src/main/kotlin/com/blueprint/service/ReviewService.kt
+++ b/src/main/kotlin/com/blueprint/service/ReviewService.kt
@@ -102,10 +102,17 @@ class ReviewService(private val project: Project) {
         }
 
         val approved = issues.isEmpty()
+        val changes = exec.patches
+            .flatMap { patch ->
+                val existing = project.service<ApplyChangesService>().readCurrentContent(patch.path)
+                PythonModelModuleRenderer.describeChanges(existing, patch.content)
+            }
+            .distinct()
+            .ifEmpty { listOf("no model changes") }
         return ReviewArtifact(
             reviewStatus = if (approved) "APPROVE" else "REQUEST_CHANGES",
             summary = if (approved) {
-                "Approved by deterministic UML model review. The patch is in scope and contains all declared UML model classes and fields."
+                "Approved by deterministic UML model review. Changes: ${changes.joinToString("; ")}."
             } else {
                 "Model patch needs revision before apply."
             },
@@ -122,7 +129,11 @@ class ReviewService(private val project: Project) {
                 )
             },
             issues = issues,
-            positiveSignals = if (approved) listOf("Deterministic schema review avoided LLM false negatives.") else emptyList(),
+            positiveSignals = if (approved) {
+                listOf("Deterministic schema review avoided LLM false negatives.", "Changed symbols: ${changes.joinToString("; ")}.")
+            } else {
+                emptyList()
+            },
             recommendedNextAction = if (approved) "apply" else "revise",
             followUpChecks = listOf("Preview the diff before applying."),
         )

--- a/src/test/kotlin/com/blueprint/ir/GoldenCodebaseFlowTest.kt
+++ b/src/test/kotlin/com/blueprint/ir/GoldenCodebaseFlowTest.kt
@@ -1,8 +1,10 @@
 package com.blueprint.ir
 
+import com.blueprint.model.NodeContract
 import com.blueprint.model.Patch
 import com.blueprint.service.DiskSnapshot
 import com.blueprint.service.PatchFreshness
+import com.blueprint.service.PythonModelModuleRenderer
 import com.blueprint.service.UmlImportService
 import com.intellij.openapi.project.Project
 import org.junit.Assert.assertEquals
@@ -141,13 +143,15 @@ class GoldenCodebaseFlowTest {
             class InvitePolicy {
               max_invites: int
               domain: str
+              expires_on: date
             }
             InviteAuditLog --> Invite : references
             Invite --> InvitePolicy : references
         """.trimIndent()
         val parsedUml = UmlImportService(fakeProject("golden-invite")).parse(uml)
         val umlIr = UmlToIR.toIR(parsedUml, "golden-invite")
-        val generatedModels = renderDataclasses(umlIr)
+        val generatedModels = renderDataclasses(umlIr, existingContent = Files.readString(models))
+        assertTrue(generatedModels.contains("from datetime import date, datetime"))
         val patch = Patch(
             path = "blueprint_demo/imported_invite/models.py",
             action = "update",
@@ -169,6 +173,7 @@ class GoldenCodebaseFlowTest {
         assertTrue(audit.fields.any { it.name == "reason" && it.type == "str" })
         assertTrue(audit.fields.any { it.name == "invite" && it.type == "Invite" })
         assertTrue(policy.fields.any { it.name == "max_invites" && it.type == "int" })
+        assertTrue(policy.fields.any { it.name == "expires_on" && it.type == "date" })
 
         val refreshedIr = fixtureIrFromSymbols("golden-invite", refreshed.symbols)
         assertTrue(refreshedIr.edges.any { edge ->
@@ -331,27 +336,20 @@ class GoldenCodebaseFlowTest {
             sourceRef = SourceRef("", line),
         )
 
-    private fun renderDataclasses(ir: ArchitectureIR): String {
-        val models = ir.components.filter { it.kind == ComponentKind.MODEL }.sortedBy { it.name }
-        val usesDatetime = models.any { component -> component.fields.any { it.type.id == "datetime" } }
-        return buildString {
-            appendLine("from dataclasses import dataclass")
-            if (usesDatetime) appendLine("from datetime import datetime")
-            appendLine()
-            models.forEach { component ->
-                appendLine()
-                appendLine("@dataclass")
-                appendLine("class ${component.name}:")
-                if (component.fields.isEmpty()) {
-                    appendLine("    pass")
-                } else {
-                    component.fields.forEach { field ->
-                        appendLine("    ${field.name}: ${field.type.id}")
-                    }
-                }
-            }
-        }.trim() + "\n"
-    }
+    private fun renderDataclasses(ir: ArchitectureIR, existingContent: String): String =
+        PythonModelModuleRenderer.render(
+            ir.components
+                .filter { it.kind == ComponentKind.MODEL }
+                .map { component ->
+                    NodeContract(
+                        name = component.name,
+                        kind = "schema",
+                        description = "Data model ${component.name}",
+                        schema = component.fields.joinToString("\n") { field -> "${field.name}: ${field.type.id}" },
+                    )
+                },
+            existingContent = existingContent,
+        )
 
     private fun componentId(name: String, relPath: String): String =
         relPath.removeSuffix(".py").replace('/', '.').trim('.').let { module ->

--- a/src/test/kotlin/com/blueprint/service/PythonModelModuleRendererTest.kt
+++ b/src/test/kotlin/com/blueprint/service/PythonModelModuleRendererTest.kt
@@ -1,0 +1,171 @@
+package com.blueprint.service
+
+import com.blueprint.model.NodeContract
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PythonModelModuleRendererTest {
+    @Test
+    fun `fresh module imports date and datetime field types`() {
+        val rendered = PythonModelModuleRenderer.render(
+            listOf(
+                NodeContract(
+                    name = "Invite",
+                    kind = "schema",
+                    schema = """
+                        id: str
+                        created_at: datetime
+                        expires_on: date
+                    """.trimIndent(),
+                ),
+            ),
+        )
+
+        assertTrue(rendered.contains("from dataclasses import dataclass\n"))
+        assertTrue(rendered.contains("from datetime import date, datetime\n"))
+        assertTrue(rendered.contains("created_at: datetime"))
+        assertTrue(rendered.contains("expires_on: date"))
+    }
+
+    @Test
+    fun `fresh module orders referenced models before dependents`() {
+        val rendered = PythonModelModuleRenderer.render(
+            listOf(
+                NodeContract(
+                    name = "InventoryVehicle",
+                    kind = "schema",
+                    schema = """
+                        vin: str
+                        model: VehicleModel
+                        warranty_policy: WarrantyPolicy
+                        listed_on: date
+                    """.trimIndent(),
+                ),
+                NodeContract(
+                    name = "WarrantyPolicy",
+                    kind = "schema",
+                    schema = """
+                        id: str
+                        months: int
+                    """.trimIndent(),
+                ),
+                NodeContract(
+                    name = "VehicleModel",
+                    kind = "schema",
+                    schema = """
+                        id: str
+                        name: str
+                    """.trimIndent(),
+                ),
+            ),
+        )
+
+        assertTrue(rendered.contains("from datetime import date\n"))
+        assertTrue(
+            "dependencies should be rendered before InventoryVehicle",
+            rendered.indexOf("class WarrantyPolicy:") < rendered.indexOf("class InventoryVehicle:") &&
+                rendered.indexOf("class VehicleModel:") < rendered.indexOf("class InventoryVehicle:"),
+        )
+    }
+
+    @Test
+    fun `merge preserves existing methods while replacing generated fields`() {
+        val existing = """
+            from dataclasses import dataclass
+
+            @dataclass
+            class InventoryVehicle:
+                vin: str
+
+                def mark_sold(self) -> None:
+                    self.status = "sold"
+        """.trimIndent()
+
+        val result = PythonModelModuleRenderer.renderWithReport(
+            listOf(
+                NodeContract(
+                    name = "InventoryVehicle",
+                    kind = "schema",
+                    schema = """
+                        vin: str
+                        status: str
+                        listed_on: date
+                    """.trimIndent(),
+                ),
+            ),
+            existingContent = existing,
+        )
+        val rendered = result.content
+
+        assertEquals(1, Regex("@dataclass").findAll(rendered).count())
+        assertTrue(rendered.contains("from datetime import date\n"))
+        assertTrue(rendered.contains("    vin: str\n    status: str\n    listed_on: date\n\n    def mark_sold"))
+        assertTrue(rendered.contains("self.status = \"sold\""))
+        assertEquals(
+            listOf("add field InventoryVehicle.status", "add field InventoryVehicle.listed_on", "add import from datetime import date"),
+            result.changes,
+        )
+    }
+
+    @Test
+    fun `merge preserves unrelated top level code`() {
+        val existing = """
+            from dataclasses import dataclass
+
+            class Helper:
+                pass
+
+            def build_slug(value: str) -> str:
+                return value.lower()
+        """.trimIndent()
+
+        val rendered = PythonModelModuleRenderer.render(
+            listOf(
+                NodeContract(
+                    name = "WarrantyPolicy",
+                    kind = "schema",
+                    schema = """
+                        id: str
+                        expires_on: date
+                    """.trimIndent(),
+                ),
+            ),
+            existingContent = existing,
+        )
+
+        assertTrue(rendered.contains("class Helper:\n    pass"))
+        assertTrue(rendered.contains("def build_slug(value: str) -> str:\n    return value.lower()"))
+        assertTrue(rendered.contains("class WarrantyPolicy:"))
+        assertTrue(rendered.contains("expires_on: date"))
+    }
+
+    @Test
+    fun `merge can repair missing imports without reporting field changes`() {
+        val existing = """
+            from dataclasses import dataclass
+
+            @dataclass
+            class Invite:
+                id: str
+                expires_on: date
+        """.trimIndent()
+
+        val result = PythonModelModuleRenderer.renderWithReport(
+            listOf(
+                NodeContract(
+                    name = "Invite",
+                    kind = "schema",
+                    schema = """
+                        id: str
+                        expires_on: date
+                    """.trimIndent(),
+                ),
+            ),
+            existingContent = existing,
+        )
+
+        assertTrue(result.content.contains("from datetime import date\n"))
+        assertEquals(listOf("add import from datetime import date"), result.changes)
+    }
+}


### PR DESCRIPTION
Closes #17.\n\n## Summary\n- replace the aggregate model generator with an AST-backed Python model renderer\n- preserve existing methods, unrelated top-level code, and generated class ordering while adding required imports\n- report exact model/import symbols changed in execution and deterministic review summaries\n\n## Verification\n- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew test --no-daemon