### PR TITLE
Run project validation after apply

### DIFF
--- a/src/main/kotlin/com/blueprint/service/ProjectValidationService.kt
+++ b/src/main/kotlin/com/blueprint/service/ProjectValidationService.kt
@@ -1,0 +1,253 @@
+package com.blueprint.service
+
+import com.blueprint.model.Patch
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+
+@Service(Service.Level.PROJECT)
+class ProjectValidationService(private val project: Project) {
+    private val log = Logger.getInstance(ProjectValidationService::class.java)
+
+    data class ValidationResult(
+        val status: Status,
+        val command: String = "",
+        val exitCode: Int? = null,
+        val outputExcerpt: String = "",
+        val relatedFiles: List<String> = emptyList(),
+        val durationMillis: Long = 0,
+        val reason: String = "",
+    ) {
+        enum class Status { PASS, FAIL, SKIPPED }
+
+        fun summaryLine(): String =
+            when (status) {
+                Status.PASS -> "Validation passed: $command"
+                Status.FAIL -> "Validation failed: $command"
+                Status.SKIPPED -> "Validation skipped: $reason"
+            }
+    }
+
+    fun selectedCommand(context: PythonProjectAnalyzer.PythonProjectContext = project.service<PythonProjectAnalyzer>().analyze()): String? =
+        chooseValidationCommand(context)
+
+    fun validateAfterApply(patches: List<Patch>, timeoutSeconds: Long = 45): ValidationResult {
+        val context = project.service<PythonProjectAnalyzer>().analyze()
+        val command = chooseValidationCommand(context)
+            ?: return ValidationResult(
+                status = ValidationResult.Status.SKIPPED,
+                reason = "No Python validation command was inferred for this project.",
+                relatedFiles = patches.map { it.path }.distinct(),
+            )
+        val basePath = context.basePath.ifBlank { project.basePath.orEmpty() }
+        if (basePath.isBlank()) {
+            return ValidationResult(
+                status = ValidationResult.Status.SKIPPED,
+                command = command,
+                reason = "No project base path is available.",
+                relatedFiles = patches.map { it.path }.distinct(),
+            )
+        }
+
+        val started = System.currentTimeMillis()
+        return try {
+            val primary = runCommand(command, basePath, timeoutSeconds)
+            val finalRun = if (
+                primary.exitCode != 0 &&
+                isMissingPytest(primary.output) &&
+                context.testRoots.isNotEmpty()
+            ) {
+                val fallback = runCommand(PYTEST_FALLBACK_COMMAND, basePath, timeoutSeconds)
+                fallback.copy(
+                    command = "$command; built-in test fallback",
+                    output = buildString {
+                        appendLine(primary.output.trim())
+                        appendLine()
+                        appendLine("pytest was not available; Blueprint ran its built-in test-function fallback.")
+                        append(fallback.output.trim())
+                    }.trim(),
+                )
+            } else {
+                primary
+            }
+
+            if (finalRun.timedOut) {
+                return ValidationResult(
+                    status = ValidationResult.Status.FAIL,
+                    command = finalRun.command,
+                    exitCode = null,
+                    outputExcerpt = "Validation timed out after ${timeoutSeconds}s.",
+                    relatedFiles = relatedFiles(basePath, patches, ""),
+                    durationMillis = finalRun.durationMillis,
+                    reason = "timeout",
+                )
+            }
+            ValidationResult(
+                status = if (finalRun.exitCode == 0) ValidationResult.Status.PASS else ValidationResult.Status.FAIL,
+                command = finalRun.command,
+                exitCode = finalRun.exitCode,
+                outputExcerpt = summarizeOutput(finalRun.output),
+                relatedFiles = relatedFiles(basePath, patches, finalRun.output),
+                durationMillis = finalRun.durationMillis,
+                reason = if (finalRun.exitCode == 0) "" else "exit ${finalRun.exitCode}",
+            )
+        } catch (t: Throwable) {
+            log.warn("Project validation failed to run", t)
+            ValidationResult(
+                status = ValidationResult.Status.FAIL,
+                command = command,
+                outputExcerpt = t.message ?: t.javaClass.simpleName,
+                relatedFiles = patches.map { it.path }.distinct(),
+                reason = t.javaClass.simpleName,
+                durationMillis = System.currentTimeMillis() - started,
+            )
+        }
+    }
+
+    private fun runCommand(command: String, basePath: String, timeoutSeconds: Long): CommandRun {
+        val started = System.currentTimeMillis()
+        val process = ProcessBuilder("/bin/sh", "-lc", command)
+            .directory(Paths.get(basePath).toFile())
+            .redirectErrorStream(true)
+            .start()
+        val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+        val elapsed = System.currentTimeMillis() - started
+        if (!finished) {
+            process.destroyForcibly()
+            return CommandRun(command, exitCode = null, output = "", durationMillis = elapsed, timedOut = true)
+        }
+        val output = process.inputStream.readBytes().toString(StandardCharsets.UTF_8)
+        return CommandRun(command, process.exitValue(), output, elapsed, timedOut = false)
+    }
+
+    fun validateAfterApplyAsync(
+        patches: List<Patch>,
+        timeoutSeconds: Long = 45,
+        onDone: (ValidationResult) -> Unit,
+    ) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val result = validateAfterApply(patches, timeoutSeconds)
+            ApplicationManager.getApplication().invokeLater { onDone(result) }
+        }
+    }
+
+    private fun relatedFiles(basePath: String, patches: List<Patch>, output: String): List<String> {
+        val patched = patches.map { it.path }
+        val mentioned = PYTHON_FILE.findAll(output)
+            .map { it.value.replace('\\', '/') }
+            .mapNotNull { path ->
+                val absolute = runCatching { Paths.get(path) }.getOrNull()
+                if (absolute != null && absolute.isAbsolute) {
+                    runCatching {
+                        Paths.get(basePath).normalize().relativize(absolute.normalize()).toString().replace('\\', '/')
+                    }.getOrNull()
+                } else {
+                    path.removePrefix("./")
+                }
+            }
+        return (patched + mentioned).filter { it.isNotBlank() }.distinct().take(8)
+    }
+
+    private data class CommandRun(
+        val command: String,
+        val exitCode: Int?,
+        val output: String,
+        val durationMillis: Long,
+        val timedOut: Boolean,
+    )
+
+    companion object {
+        private val PYTHON_FILE = Regex("""(?:[A-Za-z]:)?[./\w\-\s]+\.py""")
+
+        fun chooseValidationCommand(context: PythonProjectAnalyzer.PythonProjectContext): String? {
+            val inferred = context.testCommands
+                .firstOrNull { it.contains("pytest") }
+                ?: context.testCommands.firstOrNull()
+            if (!inferred.isNullOrBlank()) return inferred
+            return if (context.testRoots.isNotEmpty() || context.configFiles.any { it == "pytest.ini" || it == "pyproject.toml" }) {
+                "python -m pytest"
+            } else {
+                null
+            }
+        }
+
+        fun summarizeOutput(output: String, maxLines: Int = 14, maxChars: Int = 2_200): String {
+            val cleaned = output
+                .replace("\r\n", "\n")
+                .replace("\r", "\n")
+                .lines()
+                .dropWhile { it.isBlank() }
+                .dropLastWhile { it.isBlank() }
+            if (cleaned.isEmpty()) return "(no output)"
+
+            val interesting = cleaned.filter { line ->
+                val lower = line.lowercase()
+                lower.contains("failed") ||
+                    lower.contains("error") ||
+                    lower.contains("traceback") ||
+                    lower.contains("no module named") ||
+                    lower.contains(".py") ||
+                    lower.contains("passed") ||
+                    lower.startsWith("===") ||
+                    lower.startsWith("___")
+            }
+            val lines = (if (interesting.isNotEmpty()) interesting else cleaned.takeLast(maxLines))
+                .take(maxLines)
+            val excerpt = lines.joinToString("\n")
+            return if (excerpt.length <= maxChars) excerpt else excerpt.take(maxChars).trimEnd() + "\n..."
+        }
+
+        fun isMissingPytest(output: String): Boolean =
+            output.contains("No module named pytest", ignoreCase = true) ||
+                output.contains("No module named 'pytest'", ignoreCase = true)
+
+        private val PYTEST_FALLBACK_COMMAND = """
+            python - <<'PY'
+            import importlib.util
+            import pathlib
+            import sys
+            import traceback
+
+            root = pathlib.Path.cwd()
+            sys.path.insert(0, str(root))
+            paths = sorted(set(root.glob("tests/test_*.py")) | set(root.glob("tests/**/*_test.py")))
+            ran = 0
+            failures = 0
+
+            for path in paths:
+                module_name = "blueprint_validation_" + "_".join(path.relative_to(root).with_suffix("").parts)
+                spec = importlib.util.spec_from_file_location(module_name, path)
+                module = importlib.util.module_from_spec(spec)
+                try:
+                    spec.loader.exec_module(module)
+                except Exception:
+                    failures += 1
+                    print(f"ERROR {path.relative_to(root)}")
+                    traceback.print_exc()
+                    continue
+                for name, fn in sorted(vars(module).items()):
+                    if name.startswith("test_") and callable(fn):
+                        ran += 1
+                        try:
+                            fn()
+                        except Exception:
+                            failures += 1
+                            print(f"FAILED {path.relative_to(root)}::{name}")
+                            traceback.print_exc()
+
+            if ran == 0:
+                print("No test functions found by Blueprint fallback runner.")
+                sys.exit(5)
+            if failures:
+                print(f"{failures} failed, {ran - failures} passed via Blueprint fallback runner")
+                sys.exit(1)
+            print(f"{ran} passed via Blueprint fallback runner")
+            PY
+        """.trimIndent()
+    }
+}

--- a/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
+++ b/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
@@ -17,6 +17,7 @@ import com.blueprint.service.NodeExecutionService
 import com.blueprint.service.NodePlanningService
 import com.blueprint.service.NodeRegistry
 import com.blueprint.service.PatchFreshness
+import com.blueprint.service.ProjectValidationService
 import com.blueprint.service.PythonProjectAnalyzer
 import com.blueprint.service.PythonUmlGenerator
 import com.blueprint.service.ReviewService
@@ -432,6 +433,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
     private val execArea = JBTextArea().apply { isEditable = false }
     private val reviewArea = JBTextArea().apply { isEditable = false }
     private val secondaryTabs = JTabbedPane()
+    private val validationResults = mutableMapOf<String, ProjectValidationService.ValidationResult>()
     private val mockMode = JBCheckBox("Offline mock demo").apply {
         isSelected = codex.providerMode() == "mock"
         addActionListener {
@@ -1403,7 +1405,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
 
     private fun selectedNodeCanApply(): Boolean {
         val node = nodeList.selectedValue ?: return false
-        if (node.executionStatus == ExecutionStatus.APPLIED) return false
+        if (node.executionStatus == ExecutionStatus.APPLIED || node.executionStatus == ExecutionStatus.FAILED) return false
         val exec = registry.getExecution(node.id) ?: return false
         return exec.patches.isNotEmpty() && reviewAllowsApply(registry.getReview(node.id))
     }
@@ -2173,42 +2175,129 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         } else {
             project.service<ApplyChangesService>().applySingle(n, exec, singlePath, review)
         }
-        n.executionStatus = if (result.applied.size == patchCount && result.skipped.isEmpty()) {
-            ExecutionStatus.APPLIED
-        } else {
-            ExecutionStatus.REVIEW
-        }
-        if (n.executionStatus == ExecutionStatus.APPLIED) {
-            umlHasPendingEdits = false
-            val generated = project.service<PythonUmlGenerator>().generate()
-            loadGeneratedUml(generated)
-            showArtifactTab("UML")
-            logActivity(
-                "Freshness verified after apply: refreshed UML from disk with " +
-                    "${generated.classCount} class(es), ${generated.relationshipCount} relationship(s)."
-            )
-        }
-        registry.update(n)
-        refreshArtifactSummary()
         logActivity("Apply finished for ${n.title.ifBlank { n.id.take(8) }}: ${result.applied.size} applied, ${result.skipped.size} skipped.")
-        status("Apply finished: ${result.applied.size} applied, ${result.skipped.size} skipped")
         if (result.skipped.isNotEmpty()) {
+            n.executionStatus = ExecutionStatus.REVIEW
+            registry.update(n)
+            refreshArtifactSummary()
+            status("Apply finished: ${result.applied.size} applied, ${result.skipped.size} skipped")
             Messages.showWarningDialog(
                 project,
                 "Skipped:\n" + result.skipped.joinToString("\n") { "${it.first} - ${it.second}" },
                 "Blueprint - Some changes skipped",
             )
-        } else {
-            Messages.showInfoMessage(
-                project,
-                "Applied ${result.applied.size} file change(s).\n\n${result.applied.joinToString("\n")}",
-                "Blueprint - Apply Complete"
-            )
+            return
         }
+
+        if (result.applied.size != patchCount) {
+            n.executionStatus = ExecutionStatus.REVIEW
+            registry.update(n)
+            refreshArtifactSummary()
+            status("Apply finished: ${result.applied.size} applied, expected $patchCount")
+            return
+        }
+
+        val patchesToValidate = displayedPatches.ifEmpty { exec.patches }
+        runPostApplyValidation(n, patchesToValidate, result)
+    }
+
+    private fun runPostApplyValidation(
+        node: BlueprintNode,
+        patches: List<Patch>,
+        applyResult: ApplyChangesService.ApplyResult,
+    ) {
+        val validation = project.service<ProjectValidationService>()
+        val command = validation.selectedCommand()
+        node.executionStatus = ExecutionStatus.EXECUTING
+        registry.update(node)
+        refreshArtifactSummary()
+        showArtifactTab("Review")
+        safetyArea.text = if (command == null) {
+            "Applied changes. No inferred validation command was available."
+        } else {
+            "Applied changes. Running validation:\n$command"
+        }
+        status(if (command == null) "Validation skipped: no command inferred" else "Running validation: $command")
+        logActivity(
+            if (command == null) {
+                "Validation skipped after apply for ${node.title.ifBlank { node.id.take(8) }}: no command inferred."
+            } else {
+                "Running validation after apply for ${node.title.ifBlank { node.id.take(8) }}: $command"
+            }
+        )
+
+        validation.validateAfterApplyAsync(patches) { result ->
+            validationResults[node.id] = result
+            when (result.status) {
+                ProjectValidationService.ValidationResult.Status.PASS,
+                ProjectValidationService.ValidationResult.Status.SKIPPED -> {
+                    node.executionStatus = ExecutionStatus.APPLIED
+                    registry.update(node)
+                    refreshUmlAfterSuccessfulApply()
+                    refreshArtifactSummary()
+                    logActivity("${result.summaryLine()} (${result.durationMillis}ms).")
+                    status(result.summaryLine())
+                    Messages.showInfoMessage(
+                        project,
+                        buildString {
+                            append("Applied ${applyResult.applied.size} file change(s).")
+                            if (applyResult.applied.isNotEmpty()) {
+                                append("\n\n")
+                                append(applyResult.applied.joinToString("\n"))
+                            }
+                            append("\n\n")
+                            append(validationReportText(result))
+                        },
+                        "Blueprint - Apply Complete",
+                    )
+                }
+                ProjectValidationService.ValidationResult.Status.FAIL -> {
+                    node.executionStatus = ExecutionStatus.FAILED
+                    registry.update(node)
+                    refreshArtifactSummary()
+                    showArtifactTab("Review")
+                    safetyArea.text = validationReportText(result)
+                    safetyArea.foreground = BlueprintTheme.Danger
+                    logActivity("${result.summaryLine()}: ${result.reason.ifBlank { "see validation output" }}")
+                    status("Validation failed after apply")
+                    Messages.showWarningDialog(
+                        project,
+                        validationReportText(result),
+                        "Blueprint - Validation Failed",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun refreshUmlAfterSuccessfulApply() {
+        umlHasPendingEdits = false
+        val generated = project.service<PythonUmlGenerator>().generate()
+        loadGeneratedUml(generated)
+        showArtifactTab("UML")
+        logActivity(
+            "Freshness verified after apply: refreshed UML from disk with " +
+                "${generated.classCount} class(es), ${generated.relationshipCount} relationship(s)."
+        )
     }
 
     private fun reviewAllowsApply(review: ReviewArtifact?): Boolean =
         review?.reviewStatus == "APPROVE" && review.recommendedNextAction == "apply"
+
+    private fun validationReportText(result: ProjectValidationService.ValidationResult): String =
+        buildString {
+            append(result.summaryLine())
+            result.exitCode?.let { append(" (exit $it)") }
+            if (result.durationMillis > 0) append(" in ${result.durationMillis}ms")
+            if (result.outputExcerpt.isNotBlank()) {
+                append("\n\n")
+                append(result.outputExcerpt)
+            }
+            if (result.relatedFiles.isNotEmpty()) {
+                append("\n\nRelated files:\n")
+                append(result.relatedFiles.joinToString("\n") { "- $it" })
+            }
+        }
 
     private fun reviewBlockMessage(review: ReviewArtifact?): String {
         if (review == null) {
@@ -2427,18 +2516,30 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         val plan = registry.getPlan(n.id)
         val exec = registry.getExecution(n.id)
         val review = registry.getReview(n.id)
+        val validation = validationResults[n.id]
         val graph = project.service<DependencyGraphService>()
         val report = graph.analyze()
         val readiness = graph.readinessFor(n)
         updateOverviewSummary(report)
-        val canApply = !exec?.patches.isNullOrEmpty() && reviewAllowsApply(review)
+        val canApply = n.executionStatus != ExecutionStatus.APPLIED &&
+            n.executionStatus != ExecutionStatus.FAILED &&
+            !exec?.patches.isNullOrEmpty() &&
+            reviewAllowsApply(review)
         applyApprovedButton.isEnabled = canApply
-        applyApprovedButton.text = if (canApply) "Apply Approved Changes" else "Apply Blocked By Review"
-        artifactLabel.text = "Artifacts: plan=${plan?.status ?: "not planned"} | exec=${exec?.status ?: "not executed"} | review=${review?.reviewStatus ?: "not reviewed"} | node=${badgeFor(n)} | ready=${readiness.ready}"
+        applyApprovedButton.text = when {
+            canApply -> "Apply Approved Changes"
+            n.executionStatus == ExecutionStatus.FAILED -> "Validation Failed"
+            else -> "Apply Blocked By Review"
+        }
+        artifactLabel.text = "Artifacts: plan=${plan?.status ?: "not planned"} | exec=${exec?.status ?: "not executed"} | review=${review?.reviewStatus ?: "not reviewed"} | validation=${validation?.status ?: "not run"} | node=${badgeFor(n)} | ready=${readiness.ready}"
         reviewSummaryArea.text = buildString {
             append(review?.summary ?: "No review yet. Run Review before applying for the safest demo flow.")
             append("\n\n")
             append(changedFileSummary(exec))
+            if (validation != null) {
+                append("\n\n")
+                append(validation.summaryLine())
+            }
         }
 
         val issues = buildList {
@@ -2448,8 +2549,12 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         }
         val scopeDrops = exec?.validation?.risks.orEmpty().filter { it.contains("out-of-scope", ignoreCase = true) }
         safetyArea.text = when {
+            validation?.status == ProjectValidationService.ValidationResult.Status.FAIL -> validationReportText(validation)
+            validation?.status == ProjectValidationService.ValidationResult.Status.PASS -> validationReportText(validation)
+            validation?.status == ProjectValidationService.ValidationResult.Status.SKIPPED -> validationReportText(validation)
             issues.isNotEmpty() || scopeDrops.isNotEmpty() ->
                 (issues + scopeDrops).distinct().joinToString("\n") { "- $it" }
+            n.executionStatus == ExecutionStatus.FAILED -> "Validation failed after apply. Regenerate a code diff or inspect the related file before continuing."
             exec?.status == "PARTIAL" -> "Execution is PARTIAL. Inspect the diff and validation notes before applying."
             exec?.status == "BLOCKED" -> "Execution is BLOCKED. Do not apply until the node is revised."
             review?.reviewStatus == "APPROVE" -> "Review approved. Scope compliance: ${review.scopeCompliance.result}."
@@ -2462,7 +2567,11 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
             "Dependency blockers:\n" +
             readiness.reasons.joinToString("\n") { "- $it" }
         }
-        safetyArea.foreground = if (safetyArea.text.startsWith("-") || safetyArea.text.contains("BLOCKED") || safetyArea.text.contains("PARTIAL")) {
+        safetyArea.foreground = if (safetyArea.text.startsWith("-") ||
+            safetyArea.text.contains("BLOCKED") ||
+            safetyArea.text.contains("PARTIAL") ||
+            safetyArea.text.contains("failed", ignoreCase = true)
+        ) {
             BlueprintTheme.Warning
         } else {
             BlueprintTheme.Success
@@ -2627,9 +2736,13 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
 
     private fun updateGuide() {
         when {
+            nodeList.selectedValue?.executionStatus == ExecutionStatus.FAILED -> {
+                primaryActionButton.text = "Generate Code Diff"
+                guideLabel.text = "Validation failed after apply. Adjust the UML or code, then regenerate a reviewed diff."
+            }
             selectedNodeCanApply() -> {
                 primaryActionButton.text = "Apply Approved Changes"
-                guideLabel.text = "Review approved the generated diff. Apply it to disk, then refresh UML from code."
+                guideLabel.text = "Review approved the generated diff. Apply it to disk; Blueprint will validate the project after apply."
             }
             currentUmlEntityCount() == 0 -> {
             primaryActionButton.text = "Refresh UML From Code"
@@ -2689,6 +2802,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         val review = registry.getReview(node.id)
         return when {
             node.executionStatus == ExecutionStatus.APPLIED -> "APPLIED"
+            node.executionStatus == ExecutionStatus.FAILED -> "FAILED"
             node.executionStatus == ExecutionStatus.BLOCKED || exec?.status == "BLOCKED" -> "BLOCKED"
             exec?.status == "PARTIAL" -> "PARTIAL"
             review != null -> "REVIEWED"
@@ -2705,6 +2819,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
             "EXECUTED" -> BlueprintTheme.AccentSurface
             "PLANNED" -> BlueprintTheme.WarningSurface
             "BLOCKED" -> BlueprintTheme.DangerSurface
+            "FAILED" -> BlueprintTheme.DangerSurface
             "PARTIAL" -> BlueprintTheme.WarningSurface
             else -> BlueprintTheme.Surface
         }

--- a/src/test/kotlin/com/blueprint/service/ProjectValidationServiceTest.kt
+++ b/src/test/kotlin/com/blueprint/service/ProjectValidationServiceTest.kt
@@ -1,0 +1,90 @@
+package com.blueprint.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProjectValidationServiceTest {
+    @Test
+    fun `prefers inferred pytest command`() {
+        val context = context(
+            testCommands = listOf("python -m unittest discover tests", "python -m pytest"),
+            testRoots = listOf("tests"),
+        )
+
+        assertEquals("python -m pytest", ProjectValidationService.chooseValidationCommand(context))
+    }
+
+    @Test
+    fun `falls back to pytest when tests exist but analyzer has no command`() {
+        val context = context(
+            testCommands = emptyList(),
+            testRoots = listOf("tests"),
+        )
+
+        assertEquals("python -m pytest", ProjectValidationService.chooseValidationCommand(context))
+    }
+
+    @Test
+    fun `returns no command for projects without tests`() {
+        val context = context(
+            testCommands = emptyList(),
+            testRoots = emptyList(),
+            configFiles = emptyList(),
+        )
+
+        assertNull(ProjectValidationService.chooseValidationCommand(context))
+    }
+
+    @Test
+    fun `summarizes failure output to actionable lines`() {
+        val output = """
+            collected 2 items
+
+            tests/test_models.py F
+
+            =================================== FAILURES ===================================
+            ______________________ test_inventory_vehicle_policy ______________________
+            tests/test_models.py:17: in test_inventory_vehicle_policy
+                assert vehicle.warranty_policy is not None
+            E   NameError: name 'date' is not defined
+            =========================== short test summary info ============================
+            FAILED tests/test_models.py::test_inventory_vehicle_policy - NameError
+        """.trimIndent()
+
+        val excerpt = ProjectValidationService.summarizeOutput(output)
+
+        assertTrue(excerpt.contains("tests/test_models.py"))
+        assertTrue(excerpt.contains("NameError"))
+        assertTrue(excerpt.contains("FAILED"))
+    }
+
+    @Test
+    fun `summarizes passing output`() {
+        val excerpt = ProjectValidationService.summarizeOutput(".. [100%]\n2 passed in 0.03s\n")
+
+        assertTrue(excerpt.contains("passed"))
+    }
+
+    @Test
+    fun `detects missing pytest output`() {
+        assertTrue(ProjectValidationService.isMissingPytest("/opt/python: No module named pytest"))
+    }
+
+    private fun context(
+        testCommands: List<String>,
+        testRoots: List<String>,
+        configFiles: List<String> = listOf("pyproject.toml"),
+    ): PythonProjectAnalyzer.PythonProjectContext =
+        PythonProjectAnalyzer.PythonProjectContext(
+            basePath = "/tmp/project",
+            configFiles = configFiles,
+            sourceRoots = listOf("app"),
+            testRoots = testRoots,
+            packageManager = "pyproject",
+            frameworks = listOf("pytest"),
+            testCommands = testCommands,
+            notes = emptyList(),
+        )
+}


### PR DESCRIPTION
Closes #18.\n\n## Summary\n- add ProjectValidationService to choose and run inferred Python validation commands after apply\n- surface validation pass/fail/skipped status in Review/Safety, activity log, and node status\n- keep failed validation in a recovery state with output excerpt and related files\n- support demo projects when pytest is missing by attempting pytest first, then running a built-in test-function fallback\n\n## Verification\n- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew test --no-daemon\n- manually ran fallback test runner in examples/car_company_project: 2 passed\n- manually ran fallback test runner in examples/invite_project: 1 passed