### PR TITLE
Ground architecture chat in selected entities

### DIFF
--- a/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
+++ b/src/main/kotlin/com/blueprint/ui/BlueprintPanel.kt
@@ -1270,11 +1270,12 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         status("Refining UML with ${providerText()}...")
         appendChat("Blueprint", "Refining the editable UML. In live mode this uses the configured OpenAI provider/API key.")
         val currentUml = umlEditor.text
+        val grounding = chatGrounding()
         Thread {
             val result = if (codex.providerMode() == "mock") {
                 CodexClient.Result(mockUmlEdit(currentUml, message), ok = true)
             } else {
-                codex.sendPromptResult(umlChatPrompt(currentUml, message))
+                codex.sendPromptResult(umlChatPrompt(currentUml, message, grounding))
             }
             SwingUtilities.invokeLater {
                 if (!result.ok) {
@@ -1291,19 +1292,27 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
                 }
                 setUmlEditorText(nextUml, pendingEdits = true)
                 umlStatusLabel.text = "UML: refined by chat. Create Code Nodes when ready, or keep editing."
-                appendChat("Blueprint", "Updated the UML. Review it in the main canvas, then keep refining or click Create Code Nodes.")
+                appendChat(
+                    "Blueprint",
+                    "Updated the UML using ${grounding.selectedLabel}, so the edit stays tied to the selected source facts, fields, methods, and relationships. Review it in the main canvas, then keep refining or click Create Code Nodes."
+                )
                 updateGuide()
                 status("UML refined")
             }
         }.start()
     }
 
-    private fun umlChatPrompt(currentUml: String, message: String): String =
+    private fun umlChatPrompt(
+        currentUml: String,
+        message: String,
+        grounding: ChatGroundingContext.Grounding = chatGrounding(),
+    ): String =
         """
         You are Blueprint, an architecture assistant inside PyCharm.
 
         The user edits a Mermaid UML classDiagram that will later be converted into scoped code-generation nodes.
         Update the UML according to the user's request.
+        Use the grounding context to interpret pronouns like "this", "it", "selected", or "the current class".
 
         Rules:
         - Return only Mermaid classDiagram text.
@@ -1311,9 +1320,13 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         - Keep names clear and Python-friendly.
         - Prefer class blocks and simple relationship lines.
         - Do not include explanations, markdown fences, or prose.
+        - Keep changes focused on the selected entity when the request is ambiguous.
+
+        Grounding context:
+        ${grounding.promptText}
 
         Current UML:
-        $currentUml
+        ${ChatGroundingContext.compactUml(currentUml)}
 
         User request:
         $message
@@ -1323,6 +1336,7 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         val selected = nodeList.selectedValue
         val graph = project.service<DependencyGraphService>()
         val ready = graph.readyNodes()
+        val grounding = chatGrounding()
         return """
         You are Blueprint, an architecture assistant inside PyCharm.
 
@@ -1330,10 +1344,14 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         codebase -> editable UML -> chat refinement -> code nodes -> plan/execute/review/apply -> UML again.
 
         Answer the user's question clearly and briefly. Do not claim you changed code unless the user used the execution buttons.
-        When useful, refer to the current UML and generated nodes.
+        When useful, refer to the selected entity's source, fields, methods, relationships, current UML, and generated nodes.
+        If the user refers to "this", "it", or "selected", resolve that from Grounding context.
 
-        Current UML:
-        ${umlEditor.text}
+        Grounding context:
+        ${grounding.promptText}
+
+        Current UML excerpt:
+        ${ChatGroundingContext.compactUml(umlEditor.text)}
 
         Selected generated node:
         ${selected?.let { "${it.title} (${it.type.name.lowercase()}, ${badgeFor(it)})" } ?: "none"}
@@ -1344,6 +1362,17 @@ class BlueprintPanel(private val project: Project) : JPanel(BorderLayout()) {
         User question:
         $message
         """.trimIndent()
+    }
+
+    private fun chatGrounding(): ChatGroundingContext.Grounding {
+        val parsed = runCatching { project.service<UmlImportService>().parse(umlEditor.text) }.getOrNull()
+        val ir = project.service<IRStore>().load()
+        return ChatGroundingContext.build(
+            ir = ir,
+            parsedUml = parsed,
+            selectedCanvasId = selectedCanvasId,
+            viewingUmlDraft = umlHasPendingEdits,
+        )
     }
 
     private fun extractMermaid(text: String): String {

--- a/src/main/kotlin/com/blueprint/ui/ChatGroundingContext.kt
+++ b/src/main/kotlin/com/blueprint/ui/ChatGroundingContext.kt
@@ -1,0 +1,170 @@
+package com.blueprint.ui
+
+import com.blueprint.ir.ArchitectureIR
+import com.blueprint.ir.Component
+import com.blueprint.ir.Edge
+import com.blueprint.ir.EdgeKind
+import com.blueprint.service.UmlImportService
+
+/**
+ * Builds compact facts for architecture chat prompts.
+ *
+ * This intentionally sends selected structural facts instead of whole source
+ * files: source refs, fields, methods, and relationships are enough for the
+ * model to answer or refine UML in the user's current context.
+ */
+object ChatGroundingContext {
+    data class Grounding(
+        val mode: String,
+        val selectedId: String?,
+        val selectedLabel: String,
+        val promptText: String,
+    )
+
+    fun build(
+        ir: ArchitectureIR?,
+        parsedUml: UmlImportService.ParsedUml?,
+        selectedCanvasId: String?,
+        viewingUmlDraft: Boolean,
+    ): Grounding {
+        val selected = selectedCanvasId?.takeIf { it.isNotBlank() }
+
+        if (viewingUmlDraft) {
+            selected?.let { id ->
+                proposedUmlGrounding(parsedUml, id)?.let { return it }
+            }
+        }
+
+        selected?.let { id ->
+            codeGrounding(ir, id)?.let { return it }
+            proposedUmlGrounding(parsedUml, id)?.let { return it }
+        }
+
+        return noSelectionGrounding(ir, parsedUml, viewingUmlDraft)
+    }
+
+    fun compactUml(uml: String, maxLines: Int = 80, maxChars: Int = 5_000): String {
+        val normalized = uml.replace("\r\n", "\n").replace("\r", "\n").trim()
+        if (normalized.isBlank()) return "(empty)"
+        val lines = normalized.lines()
+        val clippedLines = if (lines.size > maxLines) {
+            lines.take(maxLines) + listOf("%% ... ${lines.size - maxLines} more line(s) omitted")
+        } else {
+            lines
+        }
+        val text = clippedLines.joinToString("\n")
+        return if (text.length <= maxChars) text else text.take(maxChars).trimEnd() + "\n%% ... omitted"
+    }
+
+    private fun codeGrounding(ir: ArchitectureIR?, selectedId: String): Grounding? {
+        ir ?: return null
+        val componentsById = ir.components.associateBy { it.id }
+        val component = componentsById[selectedId]
+            ?: ir.components.firstOrNull { it.name == selectedId }
+            ?: return null
+        val relatedEdges = ir.edges.filter { it.from == component.id || it.to == component.id }
+
+        val prompt = buildString {
+            appendLine("Mode: current code map")
+            appendLine("Selected code entity: ${component.name}")
+            appendLine("ID: ${component.id}")
+            appendLine("Kind: ${component.kind.name.lowercase().replace('_', ' ')}")
+            appendLine("Source: ${component.sourceLabel()}")
+            if (component.fields.isNotEmpty()) {
+                appendLine("Fields:")
+                component.fields.take(12).forEach { field -> appendLine("- ${field.name}: ${field.type}") }
+                if (component.fields.size > 12) appendLine("- +${component.fields.size - 12} more field(s)")
+            }
+            if (component.operations.isNotEmpty()) {
+                appendLine("Methods:")
+                component.operations.take(8).forEach { operation ->
+                    appendLine("- ${operation.name}(${operation.params.joinToString(", ") { it.name + ": " + it.type }}) -> ${operation.returns}")
+                }
+                if (component.operations.size > 8) appendLine("- +${component.operations.size - 8} more method(s)")
+            }
+            if (relatedEdges.isNotEmpty()) {
+                appendLine("Relationships:")
+                relatedEdges.take(12).forEach { edge ->
+                    appendLine("- ${edge.labelFor(component, componentsById)}")
+                }
+                if (relatedEdges.size > 12) appendLine("- +${relatedEdges.size - 12} more relationship(s)")
+            }
+        }.trim()
+
+        return Grounding(
+            mode = "current code map",
+            selectedId = component.id,
+            selectedLabel = "selected code entity ${component.name}",
+            promptText = prompt,
+        )
+    }
+
+    private fun proposedUmlGrounding(parsedUml: UmlImportService.ParsedUml?, selectedId: String): Grounding? {
+        parsedUml ?: return null
+        val entity = parsedUml.entities.firstOrNull { it.name == selectedId } ?: return null
+        val relationships = parsedUml.relationships.filter { it.from == entity.name || it.to == entity.name }
+        val prompt = buildString {
+            appendLine("Mode: editable UML draft")
+            appendLine("Selected proposed UML entity: ${entity.name}")
+            if (entity.fields.isNotEmpty()) {
+                appendLine("Proposed fields/methods:")
+                entity.fields.take(16).forEach { appendLine("- $it") }
+                if (entity.fields.size > 16) appendLine("- +${entity.fields.size - 16} more item(s)")
+            }
+            if (relationships.isNotEmpty()) {
+                appendLine("Proposed relationships:")
+                relationships.take(12).forEach { rel -> appendLine("- ${rel.from} ${rel.label} ${rel.to}") }
+                if (relationships.size > 12) appendLine("- +${relationships.size - 12} more relationship(s)")
+            }
+        }.trim()
+        return Grounding(
+            mode = "editable UML draft",
+            selectedId = entity.name,
+            selectedLabel = "selected UML entity ${entity.name}",
+            promptText = prompt,
+        )
+    }
+
+    private fun noSelectionGrounding(
+        ir: ArchitectureIR?,
+        parsedUml: UmlImportService.ParsedUml?,
+        viewingUmlDraft: Boolean,
+    ): Grounding {
+        val prompt = buildString {
+            appendLine("Mode: ${if (viewingUmlDraft) "editable UML draft" else "current code map"}")
+            appendLine("Selected entity: none")
+            parsedUml?.entities?.takeIf { it.isNotEmpty() }?.let { entities ->
+                appendLine("UML entities in editor: ${entities.take(12).joinToString(", ") { it.name }}")
+                if (entities.size > 12) appendLine("UML entity overflow: +${entities.size - 12}")
+            }
+            ir?.components?.takeIf { it.isNotEmpty() }?.let { components ->
+                appendLine("Code entities recovered: ${components.take(12).joinToString(", ") { it.name }}")
+                if (components.size > 12) appendLine("Code entity overflow: +${components.size - 12}")
+            }
+        }.trim()
+        return Grounding(
+            mode = if (viewingUmlDraft) "editable UML draft" else "current code map",
+            selectedId = null,
+            selectedLabel = "no selected entity",
+            promptText = prompt,
+        )
+    }
+
+    private fun Component.sourceLabel(): String {
+        val ref = sourceRef
+        if (ref != null && ref.path.isNotBlank()) return "${ref.path}:${ref.line}"
+        return ownership.files.firstOrNull()?.takeIf { it.isNotBlank() } ?: "(unknown)"
+    }
+
+    private fun Edge.labelFor(selected: Component, componentsById: Map<String, Component>): String {
+        val direction = if (from == selected.id) "out" else "in"
+        val otherId = if (from == selected.id) to else from
+        val other = componentsById[otherId]?.name ?: otherId
+        val kindLabel = kind.chatLabel()
+        val edgeLabel = label.ifBlank { kindLabel }
+        return "$direction $kindLabel $other ($edgeLabel)"
+    }
+
+    private fun EdgeKind.chatLabel(): String =
+        name.lowercase().replace('_', ' ')
+}

--- a/src/test/kotlin/com/blueprint/ui/ChatGroundingContextTest.kt
+++ b/src/test/kotlin/com/blueprint/ui/ChatGroundingContextTest.kt
@@ -1,0 +1,132 @@
+package com.blueprint.ui
+
+import com.blueprint.ir.ArchitectureIR
+import com.blueprint.ir.Component
+import com.blueprint.ir.ComponentKind
+import com.blueprint.ir.Edge
+import com.blueprint.ir.EdgeKind
+import com.blueprint.ir.EdgeTargetKind
+import com.blueprint.ir.Field
+import com.blueprint.ir.Operation
+import com.blueprint.ir.Ownership
+import com.blueprint.ir.Param
+import com.blueprint.ir.SourceRef
+import com.blueprint.ir.TypeRef
+import com.blueprint.service.UmlImportService
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatGroundingContextTest {
+    @Test
+    fun `selected code entity includes source fields methods and relationships`() {
+        val grounding = ChatGroundingContext.build(
+            ir = inviteIr(),
+            parsedUml = null,
+            selectedCanvasId = "app.models.invite",
+            viewingUmlDraft = false,
+        )
+
+        assertEquals("current code map", grounding.mode)
+        assertEquals("app.models.invite", grounding.selectedId)
+        assertTrue(grounding.promptText.contains("Selected code entity: Invite"))
+        assertTrue(grounding.promptText.contains("Source: app/models.py:12"))
+        assertTrue(grounding.promptText.contains("- project: Project"))
+        assertTrue(grounding.promptText.contains("- accept() -> None"))
+        assertTrue(grounding.promptText.contains("out references Project"))
+    }
+
+    @Test
+    fun `selected proposed uml entity includes fields and edges`() {
+        val grounding = ChatGroundingContext.build(
+            ir = inviteIr(),
+            parsedUml = parsedUml(),
+            selectedCanvasId = "InvitePolicy",
+            viewingUmlDraft = true,
+        )
+
+        assertEquals("editable UML draft", grounding.mode)
+        assertEquals("InvitePolicy", grounding.selectedId)
+        assertTrue(grounding.promptText.contains("Selected proposed UML entity: InvitePolicy"))
+        assertTrue(grounding.promptText.contains("- max_invites: int"))
+        assertTrue(grounding.promptText.contains("- Project owns InvitePolicy"))
+    }
+
+    @Test
+    fun `no selection summarizes available context compactly`() {
+        val grounding = ChatGroundingContext.build(
+            ir = inviteIr(),
+            parsedUml = parsedUml(),
+            selectedCanvasId = null,
+            viewingUmlDraft = false,
+        )
+
+        assertNull(grounding.selectedId)
+        assertTrue(grounding.promptText.contains("Selected entity: none"))
+        assertTrue(grounding.promptText.contains("UML entities in editor: Project, InvitePolicy"))
+        assertTrue(grounding.promptText.contains("Code entities recovered: Invite, Project"))
+    }
+
+    @Test
+    fun `compact uml clips long diagrams`() {
+        val uml = buildString {
+            appendLine("classDiagram")
+            repeat(100) { appendLine("class Entity$it") }
+        }
+
+        val compact = ChatGroundingContext.compactUml(uml, maxLines = 10)
+
+        assertTrue(compact.lines().size <= 11)
+        assertTrue(compact.contains("more line(s) omitted"))
+    }
+
+    private fun inviteIr(): ArchitectureIR =
+        ArchitectureIR(
+            components = listOf(
+                Component(
+                    id = "app.models.invite",
+                    name = "Invite",
+                    kind = ComponentKind.MODEL,
+                    ownership = Ownership(files = listOf("app/models.py")),
+                    sourceRef = SourceRef("app/models.py", 12),
+                    fields = listOf(
+                        Field("id", TypeRef("str")),
+                        Field("project", TypeRef("Project")),
+                    ),
+                    operations = listOf(
+                        Operation("accept"),
+                        Operation("send", params = listOf(Param("email", TypeRef("str")))),
+                    ),
+                ),
+                Component(
+                    id = "app.models.project",
+                    name = "Project",
+                    kind = ComponentKind.MODEL,
+                    ownership = Ownership(files = listOf("app/models.py")),
+                    fields = listOf(Field("id", TypeRef("str"))),
+                ),
+            ),
+            edges = listOf(
+                Edge(
+                    from = "app.models.invite",
+                    to = "app.models.project",
+                    toKind = EdgeTargetKind.COMPONENT,
+                    kind = EdgeKind.REFERENCES,
+                    label = "project field",
+                ),
+            ),
+        )
+
+    private fun parsedUml(): UmlImportService.ParsedUml =
+        UmlImportService.ParsedUml(
+            entities = listOf(
+                UmlImportService.ParsedEntity("Project", listOf("id: str", "name: str")),
+                UmlImportService.ParsedEntity("InvitePolicy", listOf("max_invites: int", "domain: str")),
+            ),
+            relationships = listOf(
+                UmlImportService.ParsedRelationship("Project", "owns", "InvitePolicy"),
+            ),
+            warnings = emptyList(),
+        )
+}


### PR DESCRIPTION
Closes #20.\n\n## Summary\n- add compact chat grounding for selected code-map entities, selected UML draft entities, and no-selection state\n- include source refs, fields, methods, and relationships in live architecture chat and UML refinement prompts\n- make UML refinement responses tell the user which selected entity context grounded the edit\n\n## Verification\n- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew -Dorg.gradle.java.home=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home test --no-daemon