### PR TITLE
Add car_dealership demo project showcasing Blueprint features

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ tasks {
         untilBuild.set(providers.gradleProperty("pluginUntilBuild"))
     }
     runIde {
-        args(rootProject.layout.projectDirectory.dir("examples/invite_project").asFile.absolutePath)
+        args(rootProject.layout.projectDirectory.dir("examples/car_dealership").asFile.absolutePath)
     }
     buildSearchableOptions { enabled = false }
 }

--- a/examples/car_dealership/app/__init__.py
+++ b/examples/car_dealership/app/__init__.py
@@ -1,0 +1,1 @@
+"""Car dealership sample application used to showcase Blueprint features."""

--- a/examples/car_dealership/app/adapters/__init__.py
+++ b/examples/car_dealership/app/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""Adapters implement outbound ports (payments, notifications)."""
+
+from app.adapters.email_adapter import EmailNotificationAdapter
+from app.adapters.stripe_adapter import StripePaymentAdapter
+
+__all__ = ["EmailNotificationAdapter", "StripePaymentAdapter"]

--- a/examples/car_dealership/app/adapters/email_adapter.py
+++ b/examples/car_dealership/app/adapters/email_adapter.py
@@ -1,0 +1,28 @@
+"""Email notification adapter — concrete subclass of NotificationPort."""
+
+from __future__ import annotations
+
+from app.models.customer import Customer
+from app.models.sales import SalesOrder
+from app.ports.notification_port import NotificationPort
+
+
+class EmailNotificationAdapter(NotificationPort):
+    """Collects outbound messages in memory; a real impl would SMTP them."""
+
+    def __init__(self, sender: str = "sales@car-dealership.example") -> None:
+        self.sender = sender
+        self.sent: list[tuple[str, str, str]] = []
+
+    def send_order_confirmation(self, customer: Customer, order: SalesOrder) -> None:
+        subject = f"Order {order.id} confirmed"
+        body = (
+            f"Hi {customer.name}, your order is confirmed "
+            f"with {len(order.items)} vehicle(s). Subtotal: ${order.subtotal():.2f}."
+        )
+        self.sent.append((customer.email, subject, body))
+
+    def send_delivery_notice(self, customer: Customer, order: SalesOrder) -> None:
+        subject = f"Order {order.id} ready for delivery"
+        body = f"Hi {customer.name}, your vehicle is ready. Please schedule pickup."
+        self.sent.append((customer.email, subject, body))

--- a/examples/car_dealership/app/adapters/stripe_adapter.py
+++ b/examples/car_dealership/app/adapters/stripe_adapter.py
@@ -1,0 +1,43 @@
+"""Stripe-flavored implementation of the PaymentGateway port."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from app.models.payment import PaymentMethod, PaymentRecord, PaymentStatus
+
+
+class StripePaymentAdapter:
+    """Stubbed payment adapter that behaves like a real gateway for demo purposes."""
+
+    def __init__(self, api_key: str = "sk_test_demo") -> None:
+        self.api_key = api_key
+        self._authorized: dict[str, PaymentRecord] = {}
+
+    def authorize(self, order_id: str, amount: float, method: PaymentMethod) -> PaymentRecord:
+        record = PaymentRecord(
+            id=f"pay_{uuid.uuid4().hex[:12]}",
+            order_id=order_id,
+            method=method,
+            amount=amount,
+            status=PaymentStatus.AUTHORIZED,
+            reference=f"stripe:{uuid.uuid4().hex[:8]}",
+            recorded_at=datetime.utcnow(),
+        )
+        self._authorized[record.id] = record
+        return record
+
+    def capture(self, payment: PaymentRecord) -> PaymentRecord:
+        if payment.status != PaymentStatus.AUTHORIZED:
+            raise ValueError(f"payment {payment.id} is not authorized")
+        payment.status = PaymentStatus.CAPTURED
+        payment.recorded_at = datetime.utcnow()
+        return payment
+
+    def refund(self, payment: PaymentRecord) -> PaymentRecord:
+        if payment.status != PaymentStatus.CAPTURED:
+            raise ValueError(f"payment {payment.id} is not captured")
+        payment.status = PaymentStatus.REFUNDED
+        payment.recorded_at = datetime.utcnow()
+        return payment

--- a/examples/car_dealership/app/api.py
+++ b/examples/car_dealership/app/api.py
@@ -1,0 +1,69 @@
+"""HTTP API — routes for the dealership app.
+
+Blueprint classifies ``@router.get``/``@router.post`` handlers as ROUTE
+components. Requires ``fastapi`` (declared as an optional dependency).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from app.adapters.email_adapter import EmailNotificationAdapter
+from app.adapters.stripe_adapter import StripePaymentAdapter
+from app.models.payment import PaymentMethod
+from app.repositories.customer_repository import CustomerRepository
+from app.repositories.order_repository import OrderRepository
+from app.repositories.vehicle_repository import VehicleRepository
+from app.services.inventory_service import InventoryService
+from app.services.pricing_service import PricingService
+from app.services.sales_service import SalesService
+
+router = APIRouter()
+
+_customers = CustomerRepository()
+_vehicles = VehicleRepository()
+_orders = OrderRepository()
+_sales = SalesService(
+    orders=_orders,
+    inventory=InventoryService(_vehicles),
+    pricing=PricingService(),
+    payment_gateway=StripePaymentAdapter(),
+    notifications=EmailNotificationAdapter(),
+)
+
+
+@router.get("/dealerships/{dealership_id}/inventory")
+def list_inventory(dealership_id: str) -> list[dict]:
+    """List available vehicles at a dealership."""
+    return [
+        {
+            "stock_number": v.stock_number,
+            "description": v.vehicle.describe(),
+            "price": v.asking_price,
+        }
+        for v in _sales.inventory.available(dealership_id)
+    ]
+
+
+@router.post("/orders")
+def create_order(payload: dict) -> dict:
+    """Draft a new order for a customer."""
+    customer = _customers.find(payload["customer_id"])
+    if customer is None:
+        raise HTTPException(status_code=404, detail="customer not found")
+    order = _sales.draft_order(
+        customer=customer,
+        dealership_id=payload["dealership_id"],
+        stock_numbers=payload["stock_numbers"],
+    )
+    return {"order_id": order.id, "status": order.status.value}
+
+
+@router.post("/orders/{order_id}/charge")
+def charge_order(order_id: str, payload: dict) -> dict:
+    """Charge a drafted order and return its new status."""
+    order = _orders.find(order_id)
+    if order is None:
+        raise HTTPException(status_code=404, detail="order not found")
+    order = _sales.charge(order, PaymentMethod(payload["method"]))
+    return {"order_id": order.id, "status": order.status.value}

--- a/examples/car_dealership/app/cli.py
+++ b/examples/car_dealership/app/cli.py
@@ -1,0 +1,113 @@
+"""Operator CLI — drive the dealership app from the terminal.
+
+Blueprint will classify commands here as CLI components. Requires ``click``
+(declared as an optional dependency in ``pyproject.toml``).
+"""
+
+from __future__ import annotations
+
+import click
+
+from app.adapters.email_adapter import EmailNotificationAdapter
+from app.adapters.stripe_adapter import StripePaymentAdapter
+from app.models.customer import Customer, LoyaltyTier
+from app.models.dealership import Dealership, InventoryVehicle
+from app.models.payment import PaymentMethod
+from app.models.vehicle import GasVehicle, VehicleCondition
+from app.repositories.customer_repository import CustomerRepository
+from app.repositories.order_repository import OrderRepository
+from app.repositories.vehicle_repository import VehicleRepository
+from app.services.inventory_service import InventoryService
+from app.services.pricing_service import PricingService
+from app.services.sales_service import SalesService
+
+
+@click.group()
+def cli() -> None:
+    """Car dealership operator tools."""
+
+
+@cli.command("list-inventory")
+@click.option("--dealership-id", required=True, help="Dealership to list.")
+def list_inventory(dealership_id: str) -> None:
+    """Print available inventory for a dealership."""
+    service = _build_inventory_service()
+    for vehicle in service.available(dealership_id):
+        click.echo(f"{vehicle.stock_number}  {vehicle.vehicle.describe()}  ${vehicle.asking_price:.2f}")
+
+
+@cli.command("quote")
+@click.option("--dealership-id", required=True)
+@click.option("--stock", required=True)
+@click.option("--customer-id", required=True)
+def quote(dealership_id: str, stock: str, customer_id: str) -> None:
+    """Show a personalized quote for a customer+vehicle pair."""
+    customers, vehicles = _seed()
+    pricing = PricingService()
+    customer = customers.find(customer_id)
+    inventory = vehicles.find_by_stock(dealership_id, stock)
+    if customer is None or inventory is None:
+        raise click.ClickException("customer or vehicle not found")
+    click.echo(f"quote: ${pricing.quote(inventory, customer):.2f}")
+
+
+@cli.command("sell")
+@click.option("--dealership-id", required=True)
+@click.option("--stock", required=True)
+@click.option("--customer-id", required=True)
+@click.option("--method", type=click.Choice([m.value for m in PaymentMethod]), default="credit_card")
+def sell(dealership_id: str, stock: str, customer_id: str, method: str) -> None:
+    """Create, charge, and deliver an order end-to-end."""
+    customers, vehicles = _seed()
+    orders = OrderRepository()
+    sales = SalesService(
+        orders=orders,
+        inventory=InventoryService(vehicles),
+        pricing=PricingService(),
+        payment_gateway=StripePaymentAdapter(),
+        notifications=EmailNotificationAdapter(),
+    )
+    customer = customers.find(customer_id)
+    if customer is None:
+        raise click.ClickException(f"customer {customer_id} not found")
+    order = sales.draft_order(customer, dealership_id, [stock])
+    order = sales.charge(order, PaymentMethod(method))
+    order = sales.deliver(order)
+    click.echo(f"order {order.id} delivered, status={order.status.value}")
+
+
+def _seed() -> tuple[CustomerRepository, VehicleRepository]:
+    customers = CustomerRepository()
+    customers.save(Customer(id="cust1", name="Ada", email="ada@example.com", phone="555", loyalty_tier=LoyaltyTier.GOLD))
+
+    vehicles = VehicleRepository()
+    dealership = Dealership(id="d1", name="Blueprint Motors", city="Oslo", state="NO")
+    dealership.inventory.append(
+        InventoryVehicle(
+            stock_number="A100",
+            vehicle=GasVehicle(
+                vin="VIN1",
+                make="Honda",
+                model="Civic",
+                year=2024,
+                base_price=25000.0,
+                condition=VehicleCondition.NEW,
+                mpg_city=32,
+                mpg_highway=42,
+                fuel_tank_gallons=12.4,
+            ),
+            lot_location="A1",
+            asking_price=25000.0,
+        )
+    )
+    vehicles.save_dealership(dealership)
+    return customers, vehicles
+
+
+def _build_inventory_service() -> InventoryService:
+    _, vehicles = _seed()
+    return InventoryService(vehicles)
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/car_dealership/app/jobs.py
+++ b/examples/car_dealership/app/jobs.py
@@ -1,0 +1,42 @@
+"""Background jobs. Blueprint classifies these as JOB components."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from app.adapters.email_adapter import EmailNotificationAdapter
+from app.models.sales import OrderStatus
+from app.repositories.order_repository import OrderRepository
+
+
+class StaleQuoteReminderJob:
+    """Emails customers whose quoted orders haven't been charged in 48h."""
+
+    def __init__(self, orders: OrderRepository, notifications: EmailNotificationAdapter) -> None:
+        self.orders = orders
+        self.notifications = notifications
+
+    def execute(self, now: datetime | None = None) -> int:
+        current = now or datetime.utcnow()
+        stale_cutoff = current - timedelta(hours=48)
+        stale = [
+            o
+            for o in self.orders.by_status(OrderStatus.QUOTED)
+            if o.created_at is not None and o.created_at < stale_cutoff
+        ]
+        for order in stale:
+            self.notifications.send_order_confirmation(order.customer, order)
+        return len(stale)
+
+
+def cleanup_cancelled_orders_task(orders: OrderRepository) -> int:
+    """Purge cancelled orders older than 30 days (module-level task function)."""
+    cutoff = datetime.utcnow() - timedelta(days=30)
+    to_purge = [
+        o
+        for o in orders.by_status(OrderStatus.CANCELLED)
+        if o.created_at is not None and o.created_at < cutoff
+    ]
+    for order in to_purge:
+        orders._orders.pop(order.id, None)
+    return len(to_purge)

--- a/examples/car_dealership/app/models/__init__.py
+++ b/examples/car_dealership/app/models/__init__.py
@@ -1,0 +1,24 @@
+"""Domain models for the car dealership."""
+
+from app.models.customer import Customer, LoyaltyTier
+from app.models.dealership import Dealership, InventoryVehicle
+from app.models.payment import PaymentMethod, PaymentRecord, PaymentStatus
+from app.models.sales import LineItem, OrderStatus, SalesOrder
+from app.models.vehicle import ElectricVehicle, GasVehicle, Vehicle, VehicleCondition
+
+__all__ = [
+    "Customer",
+    "Dealership",
+    "ElectricVehicle",
+    "GasVehicle",
+    "InventoryVehicle",
+    "LineItem",
+    "LoyaltyTier",
+    "OrderStatus",
+    "PaymentMethod",
+    "PaymentRecord",
+    "PaymentStatus",
+    "SalesOrder",
+    "Vehicle",
+    "VehicleCondition",
+]

--- a/examples/car_dealership/app/models/customer.py
+++ b/examples/car_dealership/app/models/customer.py
@@ -1,0 +1,29 @@
+"""Customer records and loyalty tiers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class LoyaltyTier(Enum):
+    """Loyalty program tiers used by PricingService for discount tiers."""
+
+    STANDARD = "standard"
+    SILVER = "silver"
+    GOLD = "gold"
+    PLATINUM = "platinum"
+
+
+@dataclass
+class Customer:
+    """A buyer on file with the dealership."""
+
+    id: str
+    name: str
+    email: str
+    phone: str
+    loyalty_tier: LoyaltyTier = LoyaltyTier.STANDARD
+
+    def is_preferred(self) -> bool:
+        return self.loyalty_tier in (LoyaltyTier.GOLD, LoyaltyTier.PLATINUM)

--- a/examples/car_dealership/app/models/dealership.py
+++ b/examples/car_dealership/app/models/dealership.py
@@ -1,0 +1,38 @@
+"""Dealership location and inventory linking to Vehicle definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.models.vehicle import Vehicle, VehicleCondition
+
+
+@dataclass
+class InventoryVehicle:
+    """A physical unit on a dealership lot; wraps a Vehicle model definition."""
+
+    stock_number: str
+    vehicle: Vehicle
+    lot_location: str
+    asking_price: float
+    is_reserved: bool = False
+
+    def apply_markdown(self, amount: float) -> None:
+        self.asking_price = max(0.0, self.asking_price - amount)
+
+
+@dataclass
+class Dealership:
+    """A single dealership location with its current inventory."""
+
+    id: str
+    name: str
+    city: str
+    state: str
+    inventory: list[InventoryVehicle] = field(default_factory=list)
+
+    def available_count(self) -> int:
+        return sum(1 for v in self.inventory if not v.is_reserved)
+
+    def new_vehicles(self) -> list[InventoryVehicle]:
+        return [v for v in self.inventory if v.vehicle.condition == VehicleCondition.NEW]

--- a/examples/car_dealership/app/models/payment.py
+++ b/examples/car_dealership/app/models/payment.py
@@ -1,0 +1,37 @@
+"""Payment value objects: methods, statuses, records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class PaymentMethod(Enum):
+    """Accepted payment rails."""
+
+    CASH = "cash"
+    CREDIT_CARD = "credit_card"
+    FINANCING = "financing"
+    TRADE_IN = "trade_in"
+
+
+class PaymentStatus(Enum):
+    PENDING = "pending"
+    AUTHORIZED = "authorized"
+    CAPTURED = "captured"
+    DECLINED = "declined"
+    REFUNDED = "refunded"
+
+
+@dataclass
+class PaymentRecord:
+    """A single payment attempt against an order."""
+
+    id: str
+    order_id: str
+    method: PaymentMethod
+    amount: float
+    status: PaymentStatus = PaymentStatus.PENDING
+    reference: str = ""
+    recorded_at: datetime | None = None

--- a/examples/car_dealership/app/models/sales.py
+++ b/examples/car_dealership/app/models/sales.py
@@ -1,0 +1,53 @@
+"""Sales orders and line items that tie customers to inventory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+from app.models.customer import Customer
+from app.models.dealership import InventoryVehicle
+from app.models.payment import PaymentRecord
+
+
+class OrderStatus(Enum):
+    DRAFT = "draft"
+    QUOTED = "quoted"
+    AWAITING_PAYMENT = "awaiting_payment"
+    PAID = "paid"
+    DELIVERED = "delivered"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class LineItem:
+    """One InventoryVehicle sold as part of an order, at a negotiated price."""
+
+    inventory_vehicle: InventoryVehicle
+    sale_price: float
+    warranty_months: int = 0
+
+
+@dataclass
+class SalesOrder:
+    """A sales order connecting a Customer to one or more InventoryVehicles."""
+
+    id: str
+    customer: Customer
+    dealership_id: str
+    items: list[LineItem] = field(default_factory=list)
+    payments: list[PaymentRecord] = field(default_factory=list)
+    status: OrderStatus = OrderStatus.DRAFT
+    created_at: datetime | None = None
+
+    def subtotal(self) -> float:
+        return sum(item.sale_price for item in self.items)
+
+    def balance_due(self) -> float:
+        captured = sum(
+            p.amount
+            for p in self.payments
+            if p.status.value == "captured"
+        )
+        return max(0.0, self.subtotal() - captured)

--- a/examples/car_dealership/app/models/vehicle.py
+++ b/examples/car_dealership/app/models/vehicle.py
@@ -1,0 +1,48 @@
+"""Vehicle taxonomy: base Vehicle plus drivetrain-specific subclasses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class VehicleCondition(Enum):
+    """Inspection condition set by the dealership when a vehicle is onboarded."""
+
+    NEW = "new"
+    CERTIFIED_PRE_OWNED = "certified_pre_owned"
+    USED = "used"
+
+
+@dataclass
+class Vehicle:
+    """A make/model/year record; the canonical product definition."""
+
+    vin: str
+    make: str
+    model: str
+    year: int
+    base_price: float
+    condition: VehicleCondition = VehicleCondition.NEW
+    features: list[str] = field(default_factory=list)
+
+    def describe(self) -> str:
+        return f"{self.year} {self.make} {self.model} ({self.condition.value})"
+
+
+@dataclass
+class GasVehicle(Vehicle):
+    """Internal combustion vehicle — extends the base Vehicle model."""
+
+    mpg_city: int = 0
+    mpg_highway: int = 0
+    fuel_tank_gallons: float = 0.0
+
+
+@dataclass
+class ElectricVehicle(Vehicle):
+    """Battery-electric vehicle — extends the base Vehicle model."""
+
+    battery_kwh: float = 0.0
+    range_miles: int = 0
+    fast_charge_kw: float = 0.0

--- a/examples/car_dealership/app/ports/__init__.py
+++ b/examples/car_dealership/app/ports/__init__.py
@@ -1,0 +1,6 @@
+"""Ports — interfaces that services depend on, adapters implement."""
+
+from app.ports.notification_port import NotificationPort
+from app.ports.payment_port import PaymentGateway
+
+__all__ = ["NotificationPort", "PaymentGateway"]

--- a/examples/car_dealership/app/ports/notification_port.py
+++ b/examples/car_dealership/app/ports/notification_port.py
@@ -1,0 +1,20 @@
+"""Notification port — ABC that adapters inherit from."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from app.models.customer import Customer
+from app.models.sales import SalesOrder
+
+
+class NotificationPort(ABC):
+    """Nominal interface for notifying a customer about their order."""
+
+    @abstractmethod
+    def send_order_confirmation(self, customer: Customer, order: SalesOrder) -> None:
+        ...
+
+    @abstractmethod
+    def send_delivery_notice(self, customer: Customer, order: SalesOrder) -> None:
+        ...

--- a/examples/car_dealership/app/ports/payment_port.py
+++ b/examples/car_dealership/app/ports/payment_port.py
@@ -1,0 +1,20 @@
+"""Payment gateway port — implemented by adapters (Stripe, cash, etc.)."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.models.payment import PaymentMethod, PaymentRecord
+
+
+class PaymentGateway(Protocol):
+    """Structural interface for any payment gateway adapter."""
+
+    def authorize(self, order_id: str, amount: float, method: PaymentMethod) -> PaymentRecord:
+        ...
+
+    def capture(self, payment: PaymentRecord) -> PaymentRecord:
+        ...
+
+    def refund(self, payment: PaymentRecord) -> PaymentRecord:
+        ...

--- a/examples/car_dealership/app/repositories/__init__.py
+++ b/examples/car_dealership/app/repositories/__init__.py
@@ -1,0 +1,7 @@
+"""In-memory repositories. Replace with DB-backed adapters in production."""
+
+from app.repositories.customer_repository import CustomerRepository
+from app.repositories.order_repository import OrderRepository
+from app.repositories.vehicle_repository import VehicleRepository
+
+__all__ = ["CustomerRepository", "OrderRepository", "VehicleRepository"]

--- a/examples/car_dealership/app/repositories/customer_repository.py
+++ b/examples/car_dealership/app/repositories/customer_repository.py
@@ -1,0 +1,30 @@
+"""Customer persistence — in-memory implementation."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from app.models.customer import Customer
+
+
+class CustomerRepository:
+    """CRUD for Customer aggregates."""
+
+    def __init__(self) -> None:
+        self._customers: dict[str, Customer] = {}
+
+    def save(self, customer: Customer) -> Customer:
+        self._customers[customer.id] = customer
+        return customer
+
+    def find(self, customer_id: str) -> Optional[Customer]:
+        return self._customers.get(customer_id)
+
+    def find_by_email(self, email: str) -> Optional[Customer]:
+        for customer in self._customers.values():
+            if customer.email == email:
+                return customer
+        return None
+
+    def all(self) -> list[Customer]:
+        return list(self._customers.values())

--- a/examples/car_dealership/app/repositories/order_repository.py
+++ b/examples/car_dealership/app/repositories/order_repository.py
@@ -1,0 +1,27 @@
+"""Sales order persistence — in-memory implementation."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from app.models.sales import OrderStatus, SalesOrder
+
+
+class OrderRepository:
+    """CRUD for SalesOrder aggregates."""
+
+    def __init__(self) -> None:
+        self._orders: dict[str, SalesOrder] = {}
+
+    def save(self, order: SalesOrder) -> SalesOrder:
+        self._orders[order.id] = order
+        return order
+
+    def find(self, order_id: str) -> Optional[SalesOrder]:
+        return self._orders.get(order_id)
+
+    def by_customer(self, customer_id: str) -> list[SalesOrder]:
+        return [o for o in self._orders.values() if o.customer.id == customer_id]
+
+    def by_status(self, status: OrderStatus) -> list[SalesOrder]:
+        return [o for o in self._orders.values() if o.status == status]

--- a/examples/car_dealership/app/repositories/vehicle_repository.py
+++ b/examples/car_dealership/app/repositories/vehicle_repository.py
@@ -1,0 +1,36 @@
+"""Vehicle inventory persistence — in-memory implementation."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from app.models.dealership import Dealership, InventoryVehicle
+
+
+class VehicleRepository:
+    """CRUD for Dealership + InventoryVehicle aggregates."""
+
+    def __init__(self) -> None:
+        self._dealerships: dict[str, Dealership] = {}
+
+    def save_dealership(self, dealership: Dealership) -> Dealership:
+        self._dealerships[dealership.id] = dealership
+        return dealership
+
+    def find_dealership(self, dealership_id: str) -> Optional[Dealership]:
+        return self._dealerships.get(dealership_id)
+
+    def find_available(self, dealership_id: str) -> list[InventoryVehicle]:
+        dealership = self._dealerships.get(dealership_id)
+        if dealership is None:
+            return []
+        return [v for v in dealership.inventory if not v.is_reserved]
+
+    def find_by_stock(self, dealership_id: str, stock_number: str) -> Optional[InventoryVehicle]:
+        dealership = self._dealerships.get(dealership_id)
+        if dealership is None:
+            return None
+        for vehicle in dealership.inventory:
+            if vehicle.stock_number == stock_number:
+                return vehicle
+        return None

--- a/examples/car_dealership/app/services/__init__.py
+++ b/examples/car_dealership/app/services/__init__.py
@@ -1,0 +1,7 @@
+"""Application services orchestrate repositories, ports, and adapters."""
+
+from app.services.inventory_service import InventoryService
+from app.services.pricing_service import PricingService
+from app.services.sales_service import SalesService
+
+__all__ = ["InventoryService", "PricingService", "SalesService"]

--- a/examples/car_dealership/app/services/inventory_service.py
+++ b/examples/car_dealership/app/services/inventory_service.py
@@ -1,0 +1,35 @@
+"""Inventory lookups and reservations."""
+
+from __future__ import annotations
+
+from app.models.dealership import Dealership, InventoryVehicle
+from app.repositories.vehicle_repository import VehicleRepository
+
+
+class InventoryService:
+    """Reads/writes vehicle inventory through the VehicleRepository."""
+
+    def __init__(self, vehicles: VehicleRepository) -> None:
+        self.vehicles = vehicles
+
+    def register_dealership(self, dealership: Dealership) -> Dealership:
+        return self.vehicles.save_dealership(dealership)
+
+    def available(self, dealership_id: str) -> list[InventoryVehicle]:
+        return self.vehicles.find_available(dealership_id)
+
+    def reserve(self, dealership_id: str, stock_number: str) -> InventoryVehicle:
+        vehicle = self.vehicles.find_by_stock(dealership_id, stock_number)
+        if vehicle is None:
+            raise LookupError(f"stock {stock_number} not found at {dealership_id}")
+        if vehicle.is_reserved:
+            raise ValueError(f"stock {stock_number} already reserved")
+        vehicle.is_reserved = True
+        return vehicle
+
+    def release(self, dealership_id: str, stock_number: str) -> InventoryVehicle:
+        vehicle = self.vehicles.find_by_stock(dealership_id, stock_number)
+        if vehicle is None:
+            raise LookupError(f"stock {stock_number} not found at {dealership_id}")
+        vehicle.is_reserved = False
+        return vehicle

--- a/examples/car_dealership/app/services/pricing_service.py
+++ b/examples/car_dealership/app/services/pricing_service.py
@@ -1,0 +1,34 @@
+"""Quote prices, applying loyalty discounts and condition multipliers."""
+
+from __future__ import annotations
+
+from app.models.customer import Customer, LoyaltyTier
+from app.models.dealership import InventoryVehicle
+from app.models.vehicle import VehicleCondition
+
+
+class PricingService:
+    """Pure pricing logic, no I/O."""
+
+    LOYALTY_DISCOUNTS: dict[LoyaltyTier, float] = {
+        LoyaltyTier.STANDARD: 0.00,
+        LoyaltyTier.SILVER: 0.02,
+        LoyaltyTier.GOLD: 0.05,
+        LoyaltyTier.PLATINUM: 0.08,
+    }
+
+    CONDITION_MULTIPLIERS: dict[VehicleCondition, float] = {
+        VehicleCondition.NEW: 1.00,
+        VehicleCondition.CERTIFIED_PRE_OWNED: 0.88,
+        VehicleCondition.USED: 0.75,
+    }
+
+    def list_price(self, inventory_vehicle: InventoryVehicle) -> float:
+        base = inventory_vehicle.vehicle.base_price
+        multiplier = self.CONDITION_MULTIPLIERS[inventory_vehicle.vehicle.condition]
+        return round(base * multiplier, 2)
+
+    def quote(self, inventory_vehicle: InventoryVehicle, customer: Customer) -> float:
+        listed = self.list_price(inventory_vehicle)
+        discount = self.LOYALTY_DISCOUNTS[customer.loyalty_tier]
+        return round(listed * (1.0 - discount), 2)

--- a/examples/car_dealership/app/services/sales_service.py
+++ b/examples/car_dealership/app/services/sales_service.py
@@ -1,0 +1,86 @@
+"""Sales orchestration — the center of the call graph."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from app.models.customer import Customer
+from app.models.payment import PaymentMethod
+from app.models.sales import LineItem, OrderStatus, SalesOrder
+from app.ports.notification_port import NotificationPort
+from app.ports.payment_port import PaymentGateway
+from app.repositories.order_repository import OrderRepository
+from app.services.inventory_service import InventoryService
+from app.services.pricing_service import PricingService
+
+
+class SalesService:
+    """Wires inventory, pricing, payment, and notifications into one order flow."""
+
+    def __init__(
+        self,
+        orders: OrderRepository,
+        inventory: InventoryService,
+        pricing: PricingService,
+        payment_gateway: PaymentGateway,
+        notifications: NotificationPort,
+    ) -> None:
+        self.orders = orders
+        self.inventory = inventory
+        self.pricing = pricing
+        self.payment_gateway = payment_gateway
+        self.notifications = notifications
+
+    def draft_order(
+        self,
+        customer: Customer,
+        dealership_id: str,
+        stock_numbers: list[str],
+        warranty_months: int = 0,
+    ) -> SalesOrder:
+        items: list[LineItem] = []
+        for stock in stock_numbers:
+            reserved = self.inventory.reserve(dealership_id, stock)
+            sale_price = self.pricing.quote(reserved, customer)
+            items.append(
+                LineItem(
+                    inventory_vehicle=reserved,
+                    sale_price=sale_price,
+                    warranty_months=warranty_months,
+                )
+            )
+        order = SalesOrder(
+            id=f"ord_{uuid.uuid4().hex[:10]}",
+            customer=customer,
+            dealership_id=dealership_id,
+            items=items,
+            status=OrderStatus.QUOTED,
+            created_at=datetime.utcnow(),
+        )
+        return self.orders.save(order)
+
+    def charge(self, order: SalesOrder, method: PaymentMethod) -> SalesOrder:
+        if order.status not in (OrderStatus.QUOTED, OrderStatus.AWAITING_PAYMENT):
+            raise ValueError(f"order {order.id} cannot be charged in status {order.status}")
+        order.status = OrderStatus.AWAITING_PAYMENT
+        payment = self.payment_gateway.authorize(order.id, order.subtotal(), method)
+        payment = self.payment_gateway.capture(payment)
+        order.payments.append(payment)
+        if order.balance_due() == 0.0:
+            order.status = OrderStatus.PAID
+            self.notifications.send_order_confirmation(order.customer, order)
+        return self.orders.save(order)
+
+    def deliver(self, order: SalesOrder) -> SalesOrder:
+        if order.status != OrderStatus.PAID:
+            raise ValueError(f"order {order.id} not paid")
+        order.status = OrderStatus.DELIVERED
+        self.notifications.send_delivery_notice(order.customer, order)
+        return self.orders.save(order)
+
+    def cancel(self, order: SalesOrder) -> SalesOrder:
+        for item in order.items:
+            self.inventory.release(order.dealership_id, item.inventory_vehicle.stock_number)
+        order.status = OrderStatus.CANCELLED
+        return self.orders.save(order)

--- a/examples/car_dealership/pyproject.toml
+++ b/examples/car_dealership/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "blueprint-car-dealership-demo"
+version = "0.1.0"
+description = "Multi-layer car dealership demo used to showcase Blueprint features."
+requires-python = ">=3.9"
+
+[project.optional-dependencies]
+cli = ["click>=8.0"]
+api = ["fastapi>=0.100"]
+dev = ["pytest>=7.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/examples/car_dealership/tests/conftest.py
+++ b/examples/car_dealership/tests/conftest.py
@@ -1,0 +1,120 @@
+"""Shared fixtures — a seeded dealership, customer, and full service wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.adapters.email_adapter import EmailNotificationAdapter
+from app.adapters.stripe_adapter import StripePaymentAdapter
+from app.models.customer import Customer, LoyaltyTier
+from app.models.dealership import Dealership, InventoryVehicle
+from app.models.vehicle import ElectricVehicle, GasVehicle, VehicleCondition
+from app.repositories.customer_repository import CustomerRepository
+from app.repositories.order_repository import OrderRepository
+from app.repositories.vehicle_repository import VehicleRepository
+from app.services.inventory_service import InventoryService
+from app.services.pricing_service import PricingService
+from app.services.sales_service import SalesService
+
+
+@pytest.fixture
+def customers() -> CustomerRepository:
+    repo = CustomerRepository()
+    repo.save(
+        Customer(
+            id="cust_ada",
+            name="Ada Lovelace",
+            email="ada@example.com",
+            phone="555-0101",
+            loyalty_tier=LoyaltyTier.GOLD,
+        )
+    )
+    repo.save(
+        Customer(
+            id="cust_basic",
+            name="Casual Carl",
+            email="carl@example.com",
+            phone="555-0102",
+            loyalty_tier=LoyaltyTier.STANDARD,
+        )
+    )
+    return repo
+
+
+@pytest.fixture
+def vehicles() -> VehicleRepository:
+    repo = VehicleRepository()
+    dealership = Dealership(id="d_oslo", name="Blueprint Motors Oslo", city="Oslo", state="NO")
+    dealership.inventory.extend(
+        [
+            InventoryVehicle(
+                stock_number="A100",
+                vehicle=GasVehicle(
+                    vin="VIN-A100",
+                    make="Honda",
+                    model="Civic",
+                    year=2024,
+                    base_price=25000.0,
+                    condition=VehicleCondition.NEW,
+                    mpg_city=32,
+                    mpg_highway=42,
+                    fuel_tank_gallons=12.4,
+                ),
+                lot_location="A1",
+                asking_price=25000.0,
+            ),
+            InventoryVehicle(
+                stock_number="B200",
+                vehicle=ElectricVehicle(
+                    vin="VIN-B200",
+                    make="Tesla",
+                    model="Model 3",
+                    year=2024,
+                    base_price=42000.0,
+                    condition=VehicleCondition.NEW,
+                    battery_kwh=75.0,
+                    range_miles=272,
+                    fast_charge_kw=170.0,
+                ),
+                lot_location="B2",
+                asking_price=42000.0,
+            ),
+            InventoryVehicle(
+                stock_number="C300",
+                vehicle=GasVehicle(
+                    vin="VIN-C300",
+                    make="Toyota",
+                    model="Camry",
+                    year=2022,
+                    base_price=18000.0,
+                    condition=VehicleCondition.CERTIFIED_PRE_OWNED,
+                    mpg_city=28,
+                    mpg_highway=39,
+                    fuel_tank_gallons=14.5,
+                ),
+                lot_location="C3",
+                asking_price=16000.0,
+            ),
+        ]
+    )
+    repo.save_dealership(dealership)
+    return repo
+
+
+@pytest.fixture
+def orders() -> OrderRepository:
+    return OrderRepository()
+
+
+@pytest.fixture
+def sales_service(
+    orders: OrderRepository,
+    vehicles: VehicleRepository,
+) -> SalesService:
+    return SalesService(
+        orders=orders,
+        inventory=InventoryService(vehicles),
+        pricing=PricingService(),
+        payment_gateway=StripePaymentAdapter(),
+        notifications=EmailNotificationAdapter(),
+    )

--- a/examples/car_dealership/tests/test_inventory_service.py
+++ b/examples/car_dealership/tests/test_inventory_service.py
@@ -1,0 +1,55 @@
+"""InventoryService and PricingService behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.customer import LoyaltyTier
+from app.repositories.customer_repository import CustomerRepository
+from app.repositories.vehicle_repository import VehicleRepository
+from app.services.inventory_service import InventoryService
+from app.services.pricing_service import PricingService
+
+
+def test_available_lists_unreserved(vehicles: VehicleRepository) -> None:
+    service = InventoryService(vehicles)
+    stocks = {v.stock_number for v in service.available("d_oslo")}
+    assert stocks == {"A100", "B200", "C300"}
+
+
+def test_reserve_then_release(vehicles: VehicleRepository) -> None:
+    service = InventoryService(vehicles)
+    service.reserve("d_oslo", "A100")
+    assert {v.stock_number for v in service.available("d_oslo")} == {"B200", "C300"}
+    service.release("d_oslo", "A100")
+    assert {v.stock_number for v in service.available("d_oslo")} == {"A100", "B200", "C300"}
+
+
+def test_reserve_double_raises(vehicles: VehicleRepository) -> None:
+    service = InventoryService(vehicles)
+    service.reserve("d_oslo", "A100")
+    with pytest.raises(ValueError):
+        service.reserve("d_oslo", "A100")
+
+
+def test_reserve_missing_raises(vehicles: VehicleRepository) -> None:
+    service = InventoryService(vehicles)
+    with pytest.raises(LookupError):
+        service.reserve("d_oslo", "ZZZZ")
+
+
+def test_pricing_quote_applies_loyalty_and_condition(
+    customers: CustomerRepository,
+    vehicles: VehicleRepository,
+) -> None:
+    pricing = PricingService()
+    ada = customers.find("cust_ada")
+    assert ada is not None and ada.loyalty_tier == LoyaltyTier.GOLD
+    new_car = vehicles.find_by_stock("d_oslo", "A100")
+    cpo_car = vehicles.find_by_stock("d_oslo", "C300")
+    assert new_car is not None and cpo_car is not None
+
+    # NEW (1.00) * GOLD (1 - 0.05) = 0.95 of base
+    assert pricing.quote(new_car, ada) == round(25000.0 * 0.95, 2)
+    # CPO (0.88) * GOLD (0.95) = 0.836 of base
+    assert pricing.quote(cpo_car, ada) == round(18000.0 * 0.88 * 0.95, 2)

--- a/examples/car_dealership/tests/test_jobs.py
+++ b/examples/car_dealership/tests/test_jobs.py
@@ -1,0 +1,35 @@
+"""Background job behavior (StaleQuoteReminderJob)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from app.adapters.email_adapter import EmailNotificationAdapter
+from app.jobs import StaleQuoteReminderJob
+from app.models.customer import Customer
+from app.models.sales import OrderStatus, SalesOrder
+from app.repositories.order_repository import OrderRepository
+
+
+def _order_aged(hours: int, order_id: str) -> SalesOrder:
+    customer = Customer(id="c", name="N", email="e@e", phone="")
+    return SalesOrder(
+        id=order_id,
+        customer=customer,
+        dealership_id="d",
+        status=OrderStatus.QUOTED,
+        created_at=datetime.utcnow() - timedelta(hours=hours),
+    )
+
+
+def test_stale_reminder_emails_old_quotes() -> None:
+    repo = OrderRepository()
+    repo.save(_order_aged(hours=72, order_id="old"))
+    repo.save(_order_aged(hours=1, order_id="fresh"))
+    notifier = EmailNotificationAdapter()
+    job = StaleQuoteReminderJob(repo, notifier)
+
+    sent_count = job.execute()
+
+    assert sent_count == 1
+    assert len(notifier.sent) == 1

--- a/examples/car_dealership/tests/test_models.py
+++ b/examples/car_dealership/tests/test_models.py
@@ -1,0 +1,78 @@
+"""Sanity checks on the domain model dataclasses and enums."""
+
+from __future__ import annotations
+
+from app.models.customer import Customer, LoyaltyTier
+from app.models.dealership import Dealership, InventoryVehicle
+from app.models.sales import LineItem, OrderStatus, SalesOrder
+from app.models.vehicle import ElectricVehicle, GasVehicle, VehicleCondition
+
+
+def test_gas_vehicle_extends_base() -> None:
+    car = GasVehicle(
+        vin="X1",
+        make="Ford",
+        model="Focus",
+        year=2023,
+        base_price=21000.0,
+        mpg_city=30,
+        mpg_highway=40,
+    )
+    assert car.describe() == "2023 Ford Focus (new)"
+    assert car.condition == VehicleCondition.NEW
+
+
+def test_electric_vehicle_extends_base() -> None:
+    ev = ElectricVehicle(
+        vin="X2",
+        make="Tesla",
+        model="Model Y",
+        year=2024,
+        base_price=52000.0,
+        battery_kwh=82.0,
+        range_miles=330,
+    )
+    assert ev.range_miles == 330
+    assert ev.condition == VehicleCondition.NEW
+
+
+def test_customer_preferred_detection() -> None:
+    gold = Customer(id="c1", name="A", email="a@x", phone="", loyalty_tier=LoyaltyTier.GOLD)
+    standard = Customer(id="c2", name="B", email="b@x", phone="")
+    assert gold.is_preferred()
+    assert not standard.is_preferred()
+
+
+def test_dealership_counts_available_only() -> None:
+    inv = InventoryVehicle(
+        stock_number="S1",
+        vehicle=GasVehicle(vin="v", make="m", model="x", year=2020, base_price=1.0),
+        lot_location="L",
+        asking_price=1.0,
+    )
+    reserved = InventoryVehicle(
+        stock_number="S2",
+        vehicle=GasVehicle(vin="v2", make="m", model="x", year=2020, base_price=1.0),
+        lot_location="L",
+        asking_price=1.0,
+        is_reserved=True,
+    )
+    d = Dealership(id="d", name="n", city="c", state="s", inventory=[inv, reserved])
+    assert d.available_count() == 1
+    assert d.new_vehicles() == [inv, reserved]
+
+
+def test_sales_order_subtotal_and_balance() -> None:
+    customer = Customer(id="c", name="N", email="e", phone="")
+    item = LineItem(
+        inventory_vehicle=InventoryVehicle(
+            stock_number="S",
+            vehicle=GasVehicle(vin="v", make="m", model="x", year=2020, base_price=1.0),
+            lot_location="L",
+            asking_price=100.0,
+        ),
+        sale_price=100.0,
+    )
+    order = SalesOrder(id="o", customer=customer, dealership_id="d", items=[item], status=OrderStatus.DRAFT)
+    assert order.subtotal() == 100.0
+    assert order.balance_due() == 100.0

--- a/examples/car_dealership/tests/test_sales_flow.py
+++ b/examples/car_dealership/tests/test_sales_flow.py
@@ -1,0 +1,82 @@
+"""End-to-end sales flow: draft → charge → deliver, with cancel path."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.payment import PaymentMethod, PaymentStatus
+from app.models.sales import OrderStatus
+from app.repositories.customer_repository import CustomerRepository
+from app.repositories.order_repository import OrderRepository
+from app.repositories.vehicle_repository import VehicleRepository
+from app.services.sales_service import SalesService
+
+
+def test_happy_path_draft_charge_deliver(
+    customers: CustomerRepository,
+    vehicles: VehicleRepository,
+    orders: OrderRepository,
+    sales_service: SalesService,
+) -> None:
+    ada = customers.find("cust_ada")
+    assert ada is not None
+
+    order = sales_service.draft_order(ada, "d_oslo", ["A100", "B200"], warranty_months=12)
+    assert order.status == OrderStatus.QUOTED
+    assert len(order.items) == 2
+    # Inventory should now show those two as reserved
+    assert {v.stock_number for v in sales_service.inventory.available("d_oslo")} == {"C300"}
+
+    order = sales_service.charge(order, PaymentMethod.CREDIT_CARD)
+    assert order.status == OrderStatus.PAID
+    assert order.payments[-1].status == PaymentStatus.CAPTURED
+    assert order.balance_due() == 0.0
+
+    order = sales_service.deliver(order)
+    assert order.status == OrderStatus.DELIVERED
+
+    # Notifications side-effects: confirmation + delivery
+    sent = sales_service.notifications.sent  # type: ignore[attr-defined]
+    assert len(sent) == 2
+    assert sent[0][0] == ada.email
+    assert "confirmed" in sent[0][1].lower()
+    assert "delivery" in sent[1][1].lower()
+
+
+def test_cancel_releases_inventory(
+    customers: CustomerRepository,
+    sales_service: SalesService,
+) -> None:
+    ada = customers.find("cust_ada")
+    assert ada is not None
+    order = sales_service.draft_order(ada, "d_oslo", ["A100"])
+    assert {v.stock_number for v in sales_service.inventory.available("d_oslo")} == {"B200", "C300"}
+
+    sales_service.cancel(order)
+    assert order.status == OrderStatus.CANCELLED
+    assert {v.stock_number for v in sales_service.inventory.available("d_oslo")} == {"A100", "B200", "C300"}
+
+
+def test_deliver_before_paid_fails(
+    customers: CustomerRepository,
+    sales_service: SalesService,
+) -> None:
+    ada = customers.find("cust_ada")
+    assert ada is not None
+    order = sales_service.draft_order(ada, "d_oslo", ["A100"])
+    with pytest.raises(ValueError):
+        sales_service.deliver(order)
+
+
+def test_charge_persists_via_order_repository(
+    customers: CustomerRepository,
+    orders: OrderRepository,
+    sales_service: SalesService,
+) -> None:
+    ada = customers.find("cust_ada")
+    assert ada is not None
+    order = sales_service.draft_order(ada, "d_oslo", ["A100"])
+    sales_service.charge(order, PaymentMethod.FINANCING)
+    persisted = orders.find(order.id)
+    assert persisted is not None
+    assert persisted.status == OrderStatus.PAID

--- a/scripts/run-blueprint-pycharm.sh
+++ b/scripts/run-blueprint-pycharm.sh
@@ -7,6 +7,6 @@ export JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/
 
 echo "Launching Blueprint in a PyCharm sandbox..."
 echo "JDK: $JAVA_HOME"
-echo "Project that will open: $(pwd)/examples/invite_project"
+echo "Project that will open: $(pwd)/examples/car_dealership"
 
 ./gradlew runIde --no-daemon


### PR DESCRIPTION
Replaces invite_project as the default sandbox project. The new demo is a layered Python app — models, ports, adapters, repositories, services, CLI, HTTP routes, and jobs — designed to exercise Blueprint's full classification surface: MODEL (dataclasses + enums), PORT (Protocol + ABC), ADAPTER, SERVICE, CLI, ROUTE, JOB, TEST, plus EXTENDS/REFERENCES/CONTAINS/CALLS edges through a real draft->charge->deliver sales flow. 15 pytest cases cover the end-to-end path.